### PR TITLE
Insensitive params convert

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,12 +61,12 @@
 
     <!-- dependencies -->
     <!-- latest version from apache pulsar master -->
-    <pulsar.version>2.5.0-cc022f169</pulsar.version>
+    <pulsar.version>2.5.0-2cc34afc0</pulsar.version>
     <scala.version>2.11.12</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
     <scalatest.version>3.0.3</scalatest.version>
     <spark.version>2.4.2</spark.version>
-    <streamnative-tests.version>0.0.13</streamnative-tests.version>
+    <streamnative-tests.version>0.0.14</streamnative-tests.version>
     <testcontainers.version>1.10.6</testcontainers.version>
     <!-- plugin dependencies -->
     <maven.version>3.5.4</maven.version>

--- a/pom.xml
+++ b/pom.xml
@@ -61,12 +61,12 @@
 
     <!-- dependencies -->
     <!-- latest version from apache pulsar master -->
-    <pulsar.version>2.5.0-2cc34afc0</pulsar.version>
+    <pulsar.version>2.5.0-f6ed0377f</pulsar.version>
     <scala.version>2.11.12</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
     <scalatest.version>3.0.3</scalatest.version>
     <spark.version>2.4.2</spark.version>
-    <streamnative-tests.version>0.0.14</streamnative-tests.version>
+    <streamnative-tests.version>0.0.15</streamnative-tests.version>
     <testcontainers.version>1.10.6</testcontainers.version>
     <!-- plugin dependencies -->
     <maven.version>3.5.4</maven.version>

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarConfigurationUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarConfigurationUtils.scala
@@ -1,0 +1,45 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.pulsar
+
+import java.util.Locale
+
+import reflect.runtime.universe._
+
+import org.apache.pulsar.client.impl.conf.{ClientConfigurationData, ConsumerConfigurationData, ProducerConfigurationData, ReaderConfigurationData}
+import org.apache.pulsar.shade.com.fasterxml.jackson.annotation.JsonIgnore
+
+object PulsarConfigurationUtils {
+
+  private def nonIgnoredFields[T: TypeTag] = {
+    // a field is a Term that is a Var or a Val
+    val fields = typeOf[T].members.collect{ case s: TermSymbol => s }.
+      filter(s => s.isVal || s.isVar)
+
+    // then only keep the ones with a JsonIgnore annotation
+    val ignores = fields.flatMap(f => f.annotations.find(_.tpe =:= typeOf[JsonIgnore]).
+      map((f, _))).map(t => t._1).toList
+
+    fields.filterNot(ignores.contains).map(_.name.toString)
+  }
+
+  private def insensitive2Sensitive[T: TypeTag]: Map[String, String] = {
+    nonIgnoredFields[T].map(s => s.toLowerCase(Locale.ROOT) -> s).toMap
+  }
+
+  val clientConfKeys = insensitive2Sensitive[ClientConfigurationData]
+  val producerConfKeys = insensitive2Sensitive[ProducerConfigurationData]
+  val consumerConfKeys = insensitive2Sensitive[ConsumerConfigurationData[_]]
+  val readerConfKeys = insensitive2Sensitive[ReaderConfigurationData[_]]
+}

--- a/src/test/scala/org/apache/spark/sql/pulsar/PulsarSinkSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/pulsar/PulsarSinkSuite.scala
@@ -494,6 +494,62 @@ class PulsarSinkSuite extends StreamTest with SharedSQLContext with PulsarTest {
         .contains("__eventtime attribute type must be a bigint or timestamp"))
   }
 
+  test("batch - write to pulsar with producer conf case sensitive") {
+    val topic = newTopic()
+    val df = Seq("1", "2", "3", "4", "5") map { v =>
+      (v, v)
+    } toDF ("key", "value")
+    df.write
+      .format("pulsar")
+      .option(SERVICE_URL_OPTION_KEY, serviceUrl)
+      .option(ADMIN_URL_OPTION_KEY, adminUrl)
+      .option(TOPIC_SINGLE, topic)
+      .option("pulsar.producer.blockIfQueueFull", "true")
+      .option("pulsar.producer.maxPendingMessages", "100000")
+      .option("pulsar.producer.sendTimeoutMs", "30000")
+      .save()
+
+    checkAnswer(
+      createPulsarReader(topic).selectExpr("CAST(value as STRING) value"),
+      Row("1") :: Row("2") :: Row("3") :: Row("4") :: Row("5") :: Nil)
+  }
+
+  test("streaming - write to pulsar with producer case sensitive conf") {
+    val input = MemoryStream[String]
+    val topic = newTopic()
+
+    val writer = createPulsarWriter(
+      input.toDF(),
+      withTopic = None,
+      withOutputMode = Some(OutputMode.Append),
+      withOptions = Map(
+        "pulsar.producer.blockIfQueueFull" -> "true",
+        "pulsar.producer.maxPendingMessages" -> "100000",
+        "pulsar.producer.sendTimeoutMs" -> "30000")
+    )(withSelectExpr = s"'$topic' as __topic", "value")
+
+    val reader = createPulsarReader(topic)
+      .selectExpr("CAST(__key as STRING) __key", "CAST(value as STRING) value")
+      .selectExpr("CAST(__key as INT) __key", "CAST(value as INT) value")
+      .as[(Option[Int], Int)]
+      .map(_._2)
+
+    try {
+      input.addData("1", "2", "3", "4", "5")
+      failAfter(streamingTimeout) {
+        writer.processAllAvailable()
+      }
+      checkDatasetUnorderly(reader, 1, 2, 3, 4, 5)
+      input.addData("6", "7", "8", "9", "10")
+      failAfter(streamingTimeout) {
+        writer.processAllAvailable()
+      }
+      checkDatasetUnorderly(reader, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+    } finally {
+      writer.stop()
+    }
+  }
+
   ignore("generic - write big data with small producer buffer") {
     /* This test ensures that we understand the semantics of Pulsar when
      * is comes to blocking on a call to send when the send buffer is full.

--- a/src/test/scala/org/apache/spark/sql/pulsar/PulsarSinkSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/pulsar/PulsarSinkSuite.scala
@@ -506,6 +506,7 @@ class PulsarSinkSuite extends StreamTest with SharedSQLContext with PulsarTest {
       .option(TOPIC_SINGLE, topic)
       .option("pulsar.producer.blockIfQueueFull", "true")
       .option("pulsar.producer.maxPendingMessages", "100000")
+      .option("pulsar.producer.maxPendingMessagesAcrossPartitions", "5000000")
       .option("pulsar.producer.sendTimeoutMs", "30000")
       .save()
 
@@ -525,6 +526,7 @@ class PulsarSinkSuite extends StreamTest with SharedSQLContext with PulsarTest {
       withOptions = Map(
         "pulsar.producer.blockIfQueueFull" -> "true",
         "pulsar.producer.maxPendingMessages" -> "100000",
+        "pulsar.producer.maxPendingMessagesAcrossPartitions" -> "5000000",
         "pulsar.producer.sendTimeoutMs" -> "30000")
     )(withSelectExpr = s"'$topic' as __topic", "value")
 


### PR DESCRIPTION
For connectors, Spark would convert all user-provided parameters in `.option()` as CaseInsensitiveMap, however, pulsar's `loadConf` is case-sensitive.

This PR converts a lowercase key to the key of the exact name.