### PR TITLE
set authentication configuration in Pulsar client (#45)

### DIFF
--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarContinuousReader.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarContinuousReader.scala
@@ -62,6 +62,8 @@ class PulsarContinuousReader(
   val reportDataLoss = reportDataLossFunc(failOnDataLoss)
 
   private var offset: Offset = _
+
+  private var stopped = false
   override def setStartOffset(start: ju.Optional[Offset]): Unit = {
     offset = start.orElse {
       val actualOffsets = SpecificPulsarOffset(
@@ -129,9 +131,12 @@ class PulsarContinuousReader(
     metadataReader.commitCursorToOffset(off)
   }
 
-  override def stop(): Unit = {
-    metadataReader.removeCursor()
-    metadataReader.close()
+  override def stop(): Unit = synchronized {
+    if (!stopped) {
+      metadataReader.removeCursor()
+      metadataReader.close()
+      stopped = true
+    }
   }
 }
 

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarMicroBatchReader.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarMicroBatchReader.scala
@@ -49,6 +49,7 @@ private[pulsar] class PulsarMicroBatchReader(
 
   private var startTopicOffsets: Map[String, MessageId] = _
   private var endTopicOffsets: Map[String, MessageId] = _
+  private var stopped = false
 
   val reportDataLoss = reportDataLossFunc(failOnDataLoss)
 
@@ -151,9 +152,12 @@ private[pulsar] class PulsarMicroBatchReader(
     }.asJava
   }
 
-  override def stop(): Unit = {
-    metadataReader.removeCursor()
-    metadataReader.close()
+  override def stop(): Unit = synchronized {
+    if (!stopped) {
+      metadataReader.removeCursor()
+      metadataReader.close()
+      stopped = true
+    }
   }
 }
 

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarOptions.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarOptions.scala
@@ -19,6 +19,7 @@ import org.apache.pulsar.common.naming.TopicName
 private[pulsar] object PulsarOptions {
 
   // option key prefix for different modules
+  val PULSAR_ADMIN_OPTION_KEY_PREFIX = "pulsar.admin."
   val PULSAR_CLIENT_OPTION_KEY_PREFIX = "pulsar.client."
   val PULSAR_PRODUCER_OPTION_KEY_PREFIX = "pulsar.producer."
   val PULSAR_CONSUMER_OPTION_KEY_PREFIX = "pulsar.consumer."
@@ -47,12 +48,12 @@ private[pulsar] object PulsarOptions {
   val POLL_TIMEOUT_MS = "polltimeoutms"
   val FAIL_ON_DATA_LOSS_OPTION_KEY = "failondataloss"
 
-  val AUTH_PLUGIN_CLASS_NAME = "authpluginclassname"
-  val AUTH_PARAMS = "authparams"
-  val TLS_TRUST_CERTS_FILE_PATH = "tlstrustcertsfilepath"
-  val TLS_ALLOW_INSECURE_CONNECTION = "tlsallowinsecureconnection"
-  val USE_TLS = "usetls"
-  val TLS_HOSTNAME_VERIFICATION_ENABLE = "tlshostnameverificationenable"
+  val AUTH_PLUGIN_CLASS_NAME = "authPluginClassName"
+  val AUTH_PARAMS = "authParams"
+  val TLS_TRUST_CERTS_FILE_PATH = "tlsTrustCertsFilePath"
+  val TLS_ALLOW_INSECURE_CONNECTION = "tlsAllowInsecureConnection"
+  val USE_TLS = "useTls"
+  val TLS_HOSTNAME_VERIFICATION_ENABLE = "tlsHostnameVerificationEnable"
 
 
   val INSTRUCTION_FOR_FAIL_ON_DATA_LOSS_FALSE =

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarSource.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarSource.scala
@@ -45,6 +45,7 @@ private[pulsar] class PulsarSource(
   private val sc = sqlContext.sparkContext
 
   val reportDataLoss = reportDataLossFunc(failOnDataLoss)
+  private var stopped = false
 
   private lazy val initialTopicOffsets: SpecificPulsarOffset = {
     val metadataLog = new PulsarSourceInitialOffsetWriter(sqlContext.sparkSession, metadataPath)
@@ -163,7 +164,11 @@ private[pulsar] class PulsarSource(
   }
 
   override def stop(): Unit = synchronized {
-    metadataReader.removeCursor()
-    metadataReader.close()
+    if (!stopped) {
+      metadataReader.removeCursor()
+      metadataReader.close()
+      stopped = true
+    }
+
   }
 }

--- a/src/resources/scalastyle-config.xml
+++ b/src/resources/scalastyle-config.xml
@@ -247,7 +247,7 @@ This file is divided into 3 sections:
       <parameter name="groups">java,scala,3rdParty,pulsar,spark</parameter>
       <parameter name="group.java">javax?\..*</parameter>
       <parameter name="group.scala">scala\..*</parameter>
-      <parameter name="group.3rdParty">(?!org\.apache\.(spark|pulsar)\.).*</parameter>
+      <parameter name="group.3rdParty">(?!org(\.apache\.(spark|pulsar)|\.mockito)\.).*</parameter>
       <parameter name="group.pulsar">org\.apache\.pulsar\..*</parameter>
       <parameter name="group.spark">org\.apache\.spark\..*</parameter>
     </parameters>

--- a/src/test/scala/org/apache/spark/sql/pulsar/CachedPulsarClientSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/pulsar/CachedPulsarClientSuite.scala
@@ -13,12 +13,17 @@
  */
 package org.apache.spark.sql.pulsar
 
-import java.util.concurrent.ConcurrentMap
 import java.{util => ju}
+import java.util.concurrent.ConcurrentMap
+
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{verify, when}
 
 import org.scalatest.PrivateMethodTester
+import org.scalatest.mockito.MockitoSugar.mock
 
-import org.apache.pulsar.client.api.PulsarClient
+import org.apache.pulsar.client.api.{ClientBuilder, PulsarClient}
+
 import org.apache.spark.sql.test.SharedSQLContext
 
 class CachedPulsarClientSuite extends SharedSQLContext with PrivateMethodTester with PulsarTest {
@@ -66,5 +71,39 @@ class CachedPulsarClientSuite extends SharedSQLContext with PrivateMethodTester 
     import scala.collection.JavaConverters._
     val (seq: Seq[(String, Object)], _producer: KP) = map2.asScala.toArray.apply(0)
     assert(_producer == producer)
+  }
+
+  test("Should pass on authentication related parameters when authentication plugin is provided") {
+    val pulsarParams = new ju.HashMap[String, Object]()
+    pulsarParams.put(AUTH_PLUGIN_CLASS_NAME, "unit.test.TestAuthenticationPlugin")
+    pulsarParams.put(AUTH_PARAMS, "token:abc.def.ghi")
+    pulsarParams.put(TLS_TRUST_CERTS_FILE_PATH, "/path/to/test/tls/cert/cert.pem")
+    pulsarParams.put(TLS_ALLOW_INSECURE_CONNECTION, "false")
+    pulsarParams.put(TLS_HOSTNAME_VERIFICATION_ENABLE, "false")
+    val clientBuilderMock = mock[ClientBuilder]
+    when(clientBuilderMock.serviceUrl(any())).thenReturn(clientBuilderMock)
+    when(clientBuilderMock.loadConf(any())).thenReturn(clientBuilderMock)
+    when(clientBuilderMock.enableTlsHostnameVerification(any())).thenReturn(clientBuilderMock)
+    when(clientBuilderMock.allowTlsInsecureConnection(any())).thenReturn(clientBuilderMock)
+    when(clientBuilderMock.authentication(any())).thenReturn(clientBuilderMock)
+
+    CachedPulsarClient.createPulsarClient(pulsarParams, clientBuilderMock)
+
+    verify(clientBuilderMock).authentication("unit.test.TestAuthenticationPlugin",
+      "token:abc.def.ghi")
+    verify(clientBuilderMock).tlsTrustCertsFilePath("/path/to/test/tls/cert/cert.pem")
+    verify(clientBuilderMock).allowTlsInsecureConnection(false)
+    verify(clientBuilderMock).enableTlsHostnameVerification(false)
+    verify(clientBuilderMock).build()
+  }
+
+  test("Should build Pulsar client against test Pulsar cluster without exceptions") {
+    val pulsarParams = new ju.HashMap[String, Object]()
+    pulsarParams.put(AUTH_PLUGIN_CLASS_NAME,
+      "org.apache.pulsar.client.impl.auth.AuthenticationToken")
+    pulsarParams.put(AUTH_PARAMS, "token:abc.def.ghi")
+    pulsarParams.put(SERVICE_URL_OPTION_KEY, "pulsar://127.0.0.1:6650")
+
+    CachedPulsarClient.getOrCreate(pulsarParams)
   }
 }

--- a/src/test/scala/org/apache/spark/sql/pulsar/PulsarTest.scala
+++ b/src/test/scala/org/apache/spark/sql/pulsar/PulsarTest.scala
@@ -19,12 +19,14 @@ import java.nio.charset.StandardCharsets.UTF_8
 import java.time.Clock
 import java.util.{Map => JMap}
 
+import io.streamnative.tests.pulsar.service.{PulsarService, PulsarServiceFactory, PulsarServiceSpec}
+
 import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
+import scala.util.Random
 
 import org.scalatest.concurrent.Eventually.{eventually, timeout}
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
-import io.streamnative.tests.pulsar.service.{PulsarService, PulsarServiceFactory, PulsarServiceSpec}
 
 import com.google.common.collect.Sets
 
@@ -51,7 +53,7 @@ trait PulsarTest extends BeforeAndAfterAll with BeforeAndAfterEach {
   override def beforeAll(): Unit = {
     val spec: PulsarServiceSpec = PulsarServiceSpec
       .builder()
-      .clusterName("standalone")
+      .clusterName(s"standalone-${Random.alphanumeric.take(6).mkString}")
       .enableContainerLogging(false)
       .build()
 
@@ -79,7 +81,9 @@ trait PulsarTest extends BeforeAndAfterAll with BeforeAndAfterEach {
     CachedPulsarClient.clear()
     if (pulsarService != null) {
       pulsarService.stop()
+      pulsarService.cleanup()
     }
+
   }
 
   protected override def afterEach(): Unit = {


### PR DESCRIPTION
This PR attempts to finish the almost-complete authentication for the Pulsar connector. Briefly the following were done:
- `CachedPulsarClient` and `PulsarMetadataReader` sets authentication parameters in the Pulsar clients.
- Auth options in `PulsarOptions` were converted to camel-case, so they can be picked properly by eg. the `AdminUtils.buildAdmin` method.
- A new configuration module type called `pulsar.admin` is added. If given, this configuration is used when creating the admin interface in `PulsarMetaDataReader`. If not, the client configuration will be used.
- Added documentation about the `pulsar.admin` configuration module and some code examples on how to configure authentication when connecting.

During local testing the modified code could authenticate towards to a Pulsar cluster and receive messages from there successfully.

Please let me know what do you think about this draft approach. I will add proper unit testing around this if this can be a good way forward.

Thanks in advance!