### PR TITLE
feat: allow topics' schemas differ

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,31 @@ You can use `org.apache.spark.sql.pulsar.JsonUtils.topicOffsets(Map[String, Mess
   A batch query always fails if it fails to read any data from the provided offsets due to data loss.</td>
 
 </tr>
+<tr>
+<td>
+`allowDifferentTopicSchemas`
+</td>
+<td>
+Boolean value
+</td>
+<td>
+`false`
+</td>
+<td>
+Streaming query
+</td>
+<td>
+If multiple topics with different schemas are read, 
+using this parameter automatic schema-based topic 
+value deserialization can be turned off. 
+In that way, topics with different schemas can
+be read in the same pipeline - which is then responsible
+for deserializing the raw values based on some
+schema. Since only the raw values are returned when
+this is `true`, Pulsar topic schema(s) are not
+taken into account during operation.
+</td>
+</tr>
 
 </table>
 
@@ -387,10 +412,13 @@ df.selectExpr("CAST(__key AS STRING)", "CAST(value AS STRING)")
 ```
 
 #### Schema of Pulsar source
-* For topics without schema or with primitive schema in Pulsar, messages' payload
+- For topics without schema or with primitive schema in Pulsar, messages' payload
 is loaded to a `value` column with the corresponding type with Pulsar schema.
-
-* For topics with Avro or JSON schema, their field names and field types are kept in the result rows.
+- For topics with Avro or JSON schema, their field names and field types are kept in the result rows.
+- If the `topicsPattern` matches for topics which have different schemas, then setting
+`allowDifferentTopicSchemas` to `true` will allow the connector to read this content in a
+raw form. In this case it is the responsibility of the pipeline to apply the schema
+on this content, which is loaded to the `value` column. 
 
 Besides, each row in the source has the following metadata fields as well.
 <table class="table">

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarOptions.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarOptions.scala
@@ -56,6 +56,8 @@ private[pulsar] object PulsarOptions {
   val UseTls = "useTls"
   val TlsHostnameVerificationEnable = "tlsHostnameVerificationEnable"
 
+  val AllowDifferentTopicSchemas = "allowdifferenttopicschemas"
+
   val InstructionForFailOnDataLossFalse: String =
     """
       |Some data may have been lost because they are not available in Pulsar any more; either the

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarProvider.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarProvider.scala
@@ -67,7 +67,8 @@ private[pulsar] class PulsarProvider
         clientConfig,
         adminClientConfig,
         subscriptionNamePrefix,
-        caseInsensitiveParams)) { reader =>
+        caseInsensitiveParams,
+        getAllowDifferentTopicSchemas(parameters))) { reader =>
       reader.getAndCheckCompatible(schema)
     }
     (shortName(), inferredSchema)
@@ -90,7 +91,8 @@ private[pulsar] class PulsarProvider
       clientConfig,
       adminClientConfig,
       subscriptionNamePrefix,
-      caseInsensitiveParams)
+      caseInsensitiveParams,
+      getAllowDifferentTopicSchemas(parameters))
 
     metadataReader.getAndCheckCompatible(schema)
 
@@ -130,7 +132,8 @@ private[pulsar] class PulsarProvider
         clientConfig,
         adminClientConfig,
         subscriptionNamePrefix,
-        caseInsensitiveParams)) { reader =>
+        caseInsensitiveParams,
+        getAllowDifferentTopicSchemas(parameters))) { reader =>
       val perTopicStarts = reader.startingOffsetForEachTopic(
         caseInsensitiveParams,
         EarliestOffset)
@@ -359,6 +362,10 @@ private[pulsar] object PulsarProvider extends Logging {
 
   private def getAdminUrl(parameters: Map[String, String]): String = {
     parameters(AdminUrlOptionKey)
+  }
+
+  private def getAllowDifferentTopicSchemas(parameters: Map[String, String]): Boolean = {
+    parameters.getOrElse(AllowDifferentTopicSchemas, "false").toBoolean
   }
 
   private def failOnDataLoss(caseInsensitiveParams: Map[String, String]): Boolean =


### PR DESCRIPTION
This PR extends the connector with a boolean parameter (`deserializePayload`), using which users can skip de-serialization if we intend to read topics with multiple different schemas - by just adding an empty schema to the topic and giving back raw values upon de-serialization (that code part could remain unchanged).

**Driving usecase**: we are using the connector for reading DB table change events from Pulsar (using a single topic for a table). Since the data flow is not constant across tables (some of them has a very low inflow, while others might contain high amounts of data) we would like to create a single Spark streaming job for them. This is needed to process this data more efficiently. On the other hand, the connector cannot handle this, since different topics having the DB table change events have different schemas (this schema actually contains the columns of the tables).

Please let me know if you find this approach usable, I can add unit tests, documentation as well to the PR (and fix potential CI issues) if you think that we can proceed with this. Existing feature will not be changed, this will be an additional parameter that users of the connector can set if needed.

Moreover, there are some utility methods (eg. `SchemaUtils.pulsarSourceSchema()`) which, if exposed and documented properly, can help users to convert their messages easier (they basically do not have to write the same after fetching the topic schemas from Pulsar). What do you think about exposing these from the connector? (By importing the Pulsar connector they can be used right away.) (In order to make de-serialization easier for users we can also store the schema for the topic next to each raw value but that is not desirable since it would greatly increase the size of messages.)