### PR TITLE
Convert String to UTF8String to create string Literal

### DIFF
--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarSinks.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarSinks.scala
@@ -81,13 +81,12 @@ private[pulsar] object PulsarSinks extends Logging {
     schema
       .find(_.name == TOPIC_ATTRIBUTE_NAME)
       .getOrElse(
-        if (topic.isEmpty) {
-          throw new AnalysisException(
+        topic match {
+          case Some(topicValue) => Literal(UTF8String.fromString(topicValue), StringType)
+          case None =>throw new AnalysisException(
             s"topic option required when no " +
-              s"'$TOPIC_ATTRIBUTE_NAME' attribute is present. Use the " +
-              s"$TOPIC_SINGLE option for setting a topic.")
-        } else {
-          Literal(UTF8String.fromString(topic.get), StringType)
+              s"'$TopicAttributeName' attribute is present. Use the " +
+              s"$TopicSingle option for setting a topic.")
         }
       )
       .dataType match {

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarSinks.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarSinks.scala
@@ -25,6 +25,7 @@ import org.apache.spark.sql.catalyst.expressions.{Attribute, Literal}
 import org.apache.spark.sql.execution.QueryExecution
 import org.apache.spark.sql.execution.streaming.Sink
 import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.Utils
 
 private[pulsar] class PulsarSink(
@@ -86,7 +87,7 @@ private[pulsar] object PulsarSinks extends Logging {
               s"'$TOPIC_ATTRIBUTE_NAME' attribute is present. Use the " +
               s"$TOPIC_SINGLE option for setting a topic.")
         } else {
-          Literal(topic.get, StringType)
+          Literal(UTF8String.fromString(topic.get), StringType)
         }
       )
       .dataType match {


### PR DESCRIPTION
Fix issue #60
Form Spark 3.0.0 a validation is performed when creating Literal. If the string is not of type UTF8String the validation will fail.
The fix is to convert String to UTF8String before creating a string literal.