### PR TITLE
add: retry logic around pulsar-admin calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,46 @@ You can use `org.apache.spark.sql.pulsar.JsonUtils.topicOffsets(Map[String, Mess
   A batch query always fails if it fails to read any data from the provided offsets due to data loss.</td>
 
 </tr>
+<tr>
+<td>`maxRetries`</td>
+<td>Maximum number of retries to attempt before failing.</td>
+<td>0</td>
+<td>Streaming and batch queries</td>
+<td>Currently this *only* works for `pulsar-admin` API calls.
+The retry time is calculated using the following formula:
+
+`nextWaitTime = previousWaitTime * retryMultiplier * 
+random value from [1.0 - randomizationFactor, 1.0 + randomizationFactor]`
+
+For example, the following sequence of wait times might be generated 
+by this logic (with parameters `maxRetries=10`, `initialInterval=500`,
+`randomizationFactor=0.5`, `retryMultiplier=1.5`: 
+500 ms, 841 ms, 1587 ms, 2849 ms, 5765 ms.
+</tr>
+
+<tr>
+<td>`retryMultiplier`</td>
+<td>Real number such as `1.25`.</td>
+<td>1.5</td>
+<td>Streaming and batch queries</td>
+<td>Parameter used in conjunction with the `maxRetries` parameter.</td>
+</tr>
+
+<tr>
+<td>`initialInterval`</td>
+<td>Initial wait time in ms.</td>
+<td>500</td>
+<td>Streaming and batch queries</td>
+<td>Parameter used in conjunction with the `maxRetries` parameter.</td>
+</tr>
+
+<tr>
+<td>`randomizationFactor`</td>
+<td>Real number between 0.0 and 1.0 such as `0.75`.</td>
+<td>0.5</td>
+<td>Streaming and batch queries</td>
+<td>Parameter used in conjunction with the `maxRetries` parameter.</td>
+</tr>
 
 </table>
 

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarMetadataReader.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarMetadataReader.scala
@@ -37,6 +37,7 @@ import org.apache.spark.sql.types.StructType
 private[pulsar] case class PulsarMetadataReader(
     serviceUrl: String,
     adminUrl: String,
+    adminApiRetrier: Retrier,
     clientConf: ju.Map[String, Object],
     adminClientConf: ju.Map[String, Object],
     driverGroupIdPrefix: String,
@@ -69,7 +70,9 @@ private[pulsar] case class PulsarMetadataReader(
       case (tp, mid) =>
         val umid = mid.asInstanceOf[UserProvidedMessageId]
         try {
-          admin.topics().createSubscription(tp, s"$driverGroupIdPrefix-$tp", umid.mid)
+          adminApiRetrier.retry {
+            admin.topics().createSubscription(tp, s"$driverGroupIdPrefix-$tp", umid.mid)
+          }
         } catch {
           case e: Throwable =>
             throw new RuntimeException(
@@ -84,14 +87,22 @@ private[pulsar] case class PulsarMetadataReader(
       case (tp, time) =>
         try {
           if (time == PulsarProvider.EARLIEST_TIME) {
-            admin.topics().createSubscription(tp, s"$driverGroupIdPrefix-$tp", MessageId.earliest)
+            adminApiRetrier.retry {
+              admin.topics().createSubscription(tp, s"$driverGroupIdPrefix-$tp", MessageId.earliest)
+            }
           } else if (time == PulsarProvider.LATEST_TIME) {
-            admin.topics().createSubscription(tp, s"$driverGroupIdPrefix-$tp", MessageId.latest)
+            adminApiRetrier.retry {
+              admin.topics().createSubscription(tp, s"$driverGroupIdPrefix-$tp", MessageId.latest)
+            }
           } else if (time < 0) {
             throw new RuntimeException(s"Invalid starting time for $tp: $time")
           } else {
-            admin.topics().createSubscription(tp, s"$driverGroupIdPrefix-$tp", MessageId.latest)
-            admin.topics().resetCursor(tp, s"$driverGroupIdPrefix-$tp", time)
+            adminApiRetrier.retry {
+              admin.topics().createSubscription(tp, s"$driverGroupIdPrefix-$tp", MessageId.latest)
+            }
+            adminApiRetrier.retry {
+              admin.topics().resetCursor(tp, s"$driverGroupIdPrefix-$tp", time)
+            }
           }
         } catch {
           case e: Throwable =>
@@ -105,7 +116,9 @@ private[pulsar] case class PulsarMetadataReader(
     offset.foreach {
       case (tp, mid) =>
         try {
-          admin.topics().resetCursor(tp, s"$driverGroupIdPrefix-$tp", mid)
+          adminApiRetrier.retry {
+            admin.topics().resetCursor(tp, s"$driverGroupIdPrefix-$tp", mid)
+          }
         } catch {
           case e: PulsarAdminException if e.getStatusCode == 404 || e.getStatusCode == 412 =>
             logInfo(
@@ -122,7 +135,9 @@ private[pulsar] case class PulsarMetadataReader(
     getTopics()
     topics.foreach { tp =>
       try {
-        admin.topics().deleteSubscription(tp, s"$driverGroupIdPrefix-$tp")
+        adminApiRetrier.retry {
+          admin.topics().deleteSubscription(tp, s"$driverGroupIdPrefix-$tp")
+        }
       } catch {
         case e: PulsarAdminException if e.getStatusCode == 404 =>
           logInfo(s"Cannot remove cursor since the topic $tp has been deleted during execution.")
@@ -176,7 +191,9 @@ private[pulsar] case class PulsarMetadataReader(
 
   def getPulsarSchema(topic: String): SchemaInfo = {
     try {
-      admin.schemas().getSchemaInfo(TopicName.get(topic).toString)
+      adminApiRetrier.retry {
+        admin.schemas().getSchemaInfo(TopicName.get(topic).toString)
+      }
     } catch {
       case e: PulsarAdminException if e.getStatusCode == 404 =>
         return BytesSchema.of().getSchemaInfo
@@ -192,7 +209,9 @@ private[pulsar] case class PulsarMetadataReader(
     SpecificPulsarOffset(topicPartitions.map { tp =>
       (tp -> PulsarSourceUtils.seekableLatestMid(
         try {
-          admin.topics().getLastMessageId(tp)
+          adminApiRetrier.retry {
+            admin.topics().getLastMessageId(tp)
+          }
         } catch {
           case e: PulsarAdminException if e.getStatusCode == 404 =>
             MessageId.earliest
@@ -207,7 +226,9 @@ private[pulsar] case class PulsarMetadataReader(
 
   def fetchLatestOffsetForTopic(topic: String): MessageId = {
     PulsarSourceUtils.seekableLatestMid( try {
-      admin.topics().getLastMessageId(topic)
+      adminApiRetrier.retry {
+        admin.topics().getLastMessageId(topic)
+      }
     } catch {
       case e: PulsarAdminException if e.getStatusCode == 404 =>
         MessageId.earliest
@@ -241,7 +262,9 @@ private[pulsar] case class PulsarMetadataReader(
   private def getTopicPartitions(): Seq[String] = {
     getTopics()
     topicPartitions = topics.flatMap { tp =>
-      val partNum = admin.topics().getPartitionedTopicMetadata(tp).partitions
+      val partNum = adminApiRetrier.retry{
+        admin.topics().getPartitionedTopicMetadata(tp).partitions
+      }
       if (partNum == 0) {
         tp :: Nil
       } else {
@@ -263,7 +286,9 @@ private[pulsar] case class PulsarMetadataReader(
     val nonPartitionedMatch = topicsPatternFilter(allNonPartitionedTopics, dest.toString)
 
     val allPartitionedTopics: ju.List[String] =
-      admin.topics().getPartitionedTopicList(dest.getNamespace)
+      adminApiRetrier.retry{
+        admin.topics().getPartitionedTopicList(dest.getNamespace)
+      }
     val partitionedMatch = topicsPatternFilter(allPartitionedTopics, dest.toString)
     nonPartitionedMatch ++ partitionedMatch
   }
@@ -386,7 +411,12 @@ private[pulsar] case class PulsarMetadataReader(
           UserProvidedMessageId(MessageId.earliest)
         } else if (time == PulsarProvider.LATEST_TIME) {
           UserProvidedMessageId(
-            PulsarSourceUtils.seekableLatestMid(admin.topics().getLastMessageId(tp)))
+            PulsarSourceUtils.seekableLatestMid(
+              adminApiRetrier.retry{
+                admin.topics().getLastMessageId(tp)
+              }
+            )
+          )
         } else {
           assert (time > 0, s"time less than 0: $time")
           val reader = client
@@ -451,7 +481,12 @@ private[pulsar] case class PulsarMetadataReader(
         UserProvidedMessageId(off)
       case MessageId.latest =>
         UserProvidedMessageId(
-          PulsarSourceUtils.seekableLatestMid(admin.topics().getLastMessageId(tp)))
+          PulsarSourceUtils.seekableLatestMid(
+            adminApiRetrier.retry{
+              admin.topics().getLastMessageId(tp)
+            }
+          )
+        )
       case _ =>
         val reader = client
           .newReader()

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarOptions.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarOptions.scala
@@ -55,6 +55,10 @@ private[pulsar] object PulsarOptions {
   val USE_TLS = "useTls"
   val TLS_HOSTNAME_VERIFICATION_ENABLE = "tlsHostnameVerificationEnable"
 
+  val MaxRetries = "maxretries"
+  val RetryMultiplier = "retrymultiplier"
+  val InitialInterval = "initialinterval"
+  val RandomizationFactor = "randomizationfactor"
 
   val INSTRUCTION_FOR_FAIL_ON_DATA_LOSS_FALSE =
     """

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarProvider.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarProvider.scala
@@ -60,10 +60,27 @@ private[pulsar] class PulsarProvider
       prepareConfForReader(parameters)
 
     val subscriptionNamePrefix = s"spark-pulsar-${UUID.randomUUID}"
+    val adminApiRetrier = new SimpleRetrier(parameters
+      .getOrElse(MaxRetries, 0)
+      .toString
+      .toInt,
+      parameters
+        .getOrElse(InitialInterval, 500)
+        .toString
+        .toInt,
+      parameters
+        .getOrElse(RetryMultiplier, 1.5)
+        .toString
+        .toDouble,
+      parameters
+        .getOrElse(RandomizationFactor, 0.5)
+        .toString
+        .toDouble)
     val inferredSchema = Utils.tryWithResource(
       new PulsarMetadataReader(
         serviceUrlConfig,
         adminUrlConfig,
+        adminApiRetrier,
         clientConfig,
         adminClientConfig,
         subscriptionNamePrefix,
@@ -84,9 +101,26 @@ private[pulsar] class PulsarProvider
       prepareConfForReader(parameters)
 
     val subscriptionNamePrefix = s"spark-pulsar-${UUID.randomUUID}-${metadataPath.hashCode}"
+    val adminApiRetrier = new SimpleRetrier(parameters
+      .getOrElse(MaxRetries, 0)
+      .toString
+      .toInt,
+      parameters
+        .getOrElse(InitialInterval, 500)
+        .toString
+        .toInt,
+      parameters
+        .getOrElse(RetryMultiplier, 1.5)
+        .toString
+        .toDouble,
+      parameters
+        .getOrElse(RandomizationFactor, 0.5)
+        .toString
+        .toDouble)
     val metadataReader = new PulsarMetadataReader(
       serviceUrl,
       adminUrl,
+      adminApiRetrier,
       clientConfig,
       adminClientConfig,
       subscriptionNamePrefix,
@@ -123,10 +157,28 @@ private[pulsar] class PulsarProvider
 
     val (clientConfig, readerConfig, adminClientConfig, serviceUrl, adminUrl) =
       prepareConfForReader(parameters)
+
+    val adminApiRetrier = new SimpleRetrier(parameters
+      .getOrElse(MaxRetries, 0)
+      .toString
+      .toInt,
+      parameters
+        .getOrElse(InitialInterval, 500)
+        .toString
+        .toInt,
+      parameters
+        .getOrElse(RetryMultiplier, 1.5)
+        .toString
+        .toDouble,
+      parameters
+        .getOrElse(RandomizationFactor, 0.5)
+        .toString
+        .toDouble)
     val (start, end, schema, pSchema) = Utils.tryWithResource(
       new PulsarMetadataReader(
         serviceUrl,
         adminUrl,
+        adminApiRetrier,
         clientConfig,
         adminClientConfig,
         subscriptionNamePrefix,

--- a/src/main/scala/org/apache/spark/sql/pulsar/SimpleRetrier.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/SimpleRetrier.scala
@@ -1,0 +1,67 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.pulsar
+
+import java.security.SecureRandom
+
+import scala.util.{Failure, Success, Try}
+
+trait Retrier {
+  def retry[T](f: => T): T
+}
+
+object SimpleRetrier {
+  val DoNotRetry = 0
+}
+
+class SimpleRetrier(maxRetries: Int,
+                    waitTimeMs: Int,
+                    multiplier: Double,
+                    randomizationFactor: Double) extends Retrier {
+
+  val secRandom = new SecureRandom()
+
+  override def retry[T](retriable: => T): T = retryRec(maxRetries,
+    List[Throwable](), List[Int](waitTimeMs))(retriable)
+
+  private def retryRec[T](remainingAttempts: Int,
+                          exceptions: List[Throwable],
+                          waitTimes: List[Int])(retriable: => T): T = {
+    Try {
+      retriable
+    } match {
+      case Success(value) =>
+        value
+      case Failure(e) =>
+        if (remainingAttempts > 0) {
+          val waitTime = waitTimes.last
+          Thread.sleep(waitTime)
+          val nextWaitTime = calculateNextRetry(waitTime)
+          retryRec(remainingAttempts - 1,
+            exceptions :+ e, waitTimes :+ nextWaitTime)(retriable)
+        } else {
+          throw new RuntimeException(s"Call failed. " +
+            s"Attempted call ${maxRetries + 1} times." +
+            s"Retry wait times: ${waitTimes.map(_.toString).mkString(",")} " +
+            s"Exceptions during retry: ${exceptions.map(_.toString).mkString("\n")}. " +
+            s"Final exception:", e)
+        }
+    }
+  }
+
+  private def calculateNextRetry(previousRetry: Int) = {
+    val randomFactor = secRandom.nextFloat() * randomizationFactor + 1.0
+    (previousRetry * randomFactor * multiplier).toInt
+  }
+}

--- a/src/test/scala/org/apache/spark/sql/pulsar/SimpleRetrierSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/pulsar/SimpleRetrierSuite.scala
@@ -1,0 +1,73 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.pulsar
+
+import scala.util.{Failure, Success, Try}
+
+import org.apache.spark.SparkFunSuite
+
+class SimpleRetrierSuite extends SparkFunSuite {
+  test("shall call provided method") {
+    val testRetrier = new SimpleRetrier(SimpleRetrier.DoNotRetry, 1000, 1.5, 0.5)
+    var called = false
+    testRetrier.retry{
+      called = true
+    }
+    assert(called == true)
+  }
+
+  test("shall fail when it only tries once and fail") {
+    val testRetrier = new SimpleRetrier(SimpleRetrier.DoNotRetry, 1000, 1.5, 0.5)
+    var expectedThrowable: Throwable = null
+    val exceptionThrown = Try {
+      testRetrier.retry{
+        throw new RuntimeException("test exception")
+      }
+    } match {
+      case Success(_) => false
+      case Failure(_) => true
+    }
+    assert(exceptionThrown == true)
+  }
+
+  test("shall fail when maximum tries are exhausted") {
+    val testRetrier = new SimpleRetrier(10, 50, 1.5, 0.5)
+    var tries = 0
+    val failedWithException = Try {
+      testRetrier.retry{
+        tries += 1
+        throw new RuntimeException("test exception")
+      }
+    } match {
+      case Success(_) => false
+      case Failure(_) => true
+    }
+    assert(failedWithException == true, "Exception was not thrown after " +
+      "constantly failing retry")
+    assert(tries == 11)
+  }
+
+  test("shall pass when call succeeds after failures") {
+    val testRetrier = new SimpleRetrier(10, 50, 1.5, 0.5)
+    val succeedAfterTry = 5
+    var tries = 0
+    testRetrier.retry{
+      tries += 1
+      if (tries < succeedAfterTry) {
+        throw new RuntimeException("test exception")
+      }
+    }
+    assert(tries < 10)
+  }
+}


### PR DESCRIPTION
In some operational cases the Pulsar Admin API might return HTTP 5xx responses to the caller, which causes the pipeline to fail. Although it might be desirable to let this happen (so it can be restarted by the execution environment), but in some cases more resiliency might be needed (eg. if this happens frequently). This PR allows this to happen by adding a very minimalist retry logic and a few parameters to the connector:
- `maxRetries` to control the number of Pulsar Admin API retries (default:0)
- `waitBetweenRetries` to set the wait time between individual retries (default:500)
- `randomizationFactor` so that individual wait times can be randomized (default: 0.5)
Please let me know what do you think about this change. I would be happy to add further documentation or more integration test around this.