### PR TITLE
allow customize the reader subscription prefix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
   <groupId>io.streamnative.connectors</groupId>
   <artifactId>pulsar-spark-connector_2.12</artifactId>
-  <version>3.1.1.1</version>
+  <version>3.1.1.2</version>
   <name>StreamNative :: Pulsar Spark Connector</name>
   <url>https://pulsar.apache.org</url>
   <inceptionYear>2019</inceptionYear>

--- a/src/main/scala/org/apache/spark/sql/pulsar/AdminUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/AdminUtils.scala
@@ -24,23 +24,23 @@ object AdminUtils {
   def buildAdmin(adminUrl: String, clientConf: ju.Map[String, Object]): PulsarAdmin = {
     val builder = PulsarAdmin.builder().serviceHttpUrl(adminUrl)
 
-    if (clientConf.containsKey(AUTH_PLUGIN_CLASS_NAME)) {
+    if (clientConf.containsKey(AuthPluginClassName)) {
       builder.authentication(
-        clientConf.get(AUTH_PLUGIN_CLASS_NAME).toString, clientConf.get(AUTH_PARAMS).toString)
+        clientConf.get(AuthPluginClassName).toString, clientConf.get(AuthParams).toString)
     }
 
-    if (clientConf.containsKey(TLS_ALLOW_INSECURE_CONNECTION)) {
+    if (clientConf.containsKey(TlsAllowInsecureConnection)) {
       builder.allowTlsInsecureConnection(
-        clientConf.get(TLS_ALLOW_INSECURE_CONNECTION).toString.toBoolean)
+        clientConf.get(TlsAllowInsecureConnection).toString.toBoolean)
     }
 
-    if (clientConf.containsKey(TLS_HOSTNAME_VERIFICATION_ENABLE)) {
+    if (clientConf.containsKey(TlsHostnameVerificationEnable)) {
       builder.enableTlsHostnameVerification(
-        clientConf.get(TLS_HOSTNAME_VERIFICATION_ENABLE).toString.toBoolean)
+        clientConf.get(TlsHostnameVerificationEnable).toString.toBoolean)
     }
 
-    if (clientConf.containsKey(TLS_TRUST_CERTS_FILE_PATH)) {
-      builder.tlsTrustCertsFilePath(clientConf.get(TLS_TRUST_CERTS_FILE_PATH).toString)
+    if (clientConf.containsKey(TlsTrustCertsFilePath)) {
+      builder.tlsTrustCertsFilePath(clientConf.get(TlsTrustCertsFilePath).toString)
     }
 
     builder.build()

--- a/src/main/scala/org/apache/spark/sql/pulsar/CachedPulsarClient.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/CachedPulsarClient.scala
@@ -26,7 +26,7 @@ import org.apache.pulsar.client.api.{ClientBuilder, PulsarClient}
 
 import org.apache.spark.SparkEnv
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.pulsar.PulsarOptions.{AUTH_PARAMS, AUTH_PLUGIN_CLASS_NAME, TLS_ALLOW_INSECURE_CONNECTION, TLS_HOSTNAME_VERIFICATION_ENABLE, TLS_TRUST_CERTS_FILE_PATH}
+import org.apache.spark.sql.pulsar.PulsarOptions.{AuthParams, AuthPluginClassName, TlsAllowInsecureConnection, TlsHostnameVerificationEnable, TlsTrustCertsFilePath}
 
 private[pulsar] object CachedPulsarClient extends Logging {
 
@@ -69,11 +69,11 @@ private[pulsar] object CachedPulsarClient extends Logging {
                           pulsarConf: ju.Map[String, Object],
                           pulsarClientBuilder: ClientBuilder = PulsarClient.builder()): Client = {
     val pulsarServiceUrl =
-      pulsarConf.get(PulsarOptions.SERVICE_URL_OPTION_KEY).asInstanceOf[String]
+      pulsarConf.get(PulsarOptions.ServiceUrlOptionKey).asInstanceOf[String]
     val clientConf = new PulsarConfigUpdater(
       "pulsarClientCache",
       pulsarConf.asScala.toMap,
-      PulsarOptions.FILTERED_KEYS
+      PulsarOptions.FilteredKeys
     ).rebuild()
     logInfo(s"Client Conf = ${clientConf}")
     try {
@@ -81,21 +81,21 @@ private[pulsar] object CachedPulsarClient extends Logging {
         .serviceUrl(pulsarServiceUrl)
         .loadConf(clientConf)
       // Set TLS and authentication parameters if they were given
-      if (clientConf.containsKey(AUTH_PLUGIN_CLASS_NAME)) {
+      if (clientConf.containsKey(AuthPluginClassName)) {
         pulsarClientBuilder.authentication(
-          clientConf.get(AUTH_PLUGIN_CLASS_NAME).toString, clientConf.get(AUTH_PARAMS).toString)
+          clientConf.get(AuthPluginClassName).toString, clientConf.get(AuthParams).toString)
       }
-      if (clientConf.containsKey(TLS_ALLOW_INSECURE_CONNECTION)) {
+      if (clientConf.containsKey(TlsAllowInsecureConnection)) {
         pulsarClientBuilder.allowTlsInsecureConnection(
-          clientConf.get(TLS_ALLOW_INSECURE_CONNECTION).toString.toBoolean)
+          clientConf.get(TlsAllowInsecureConnection).toString.toBoolean)
       }
-      if (clientConf.containsKey(TLS_HOSTNAME_VERIFICATION_ENABLE)) {
+      if (clientConf.containsKey(TlsHostnameVerificationEnable)) {
         pulsarClientBuilder.enableTlsHostnameVerification(
-          clientConf.get(TLS_HOSTNAME_VERIFICATION_ENABLE).toString.toBoolean)
+          clientConf.get(TlsHostnameVerificationEnable).toString.toBoolean)
       }
-      if (clientConf.containsKey(TLS_TRUST_CERTS_FILE_PATH)) {
+      if (clientConf.containsKey(TlsTrustCertsFilePath)) {
         pulsarClientBuilder.tlsTrustCertsFilePath(
-          clientConf.get(TLS_TRUST_CERTS_FILE_PATH).toString)
+          clientConf.get(TlsTrustCertsFilePath).toString)
       }
       val pulsarClient: Client = pulsarClientBuilder.build()
       logDebug(

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarConfigUpdater.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarConfigUpdater.scala
@@ -26,7 +26,7 @@ private[pulsar] case class PulsarConfigUpdater(
     module: String,
     pulsarParams: Map[String, Object],
     blacklistedKeys: Set[String] = Set(),
-    keysToHideInLog: Set[String] = Set(PulsarOptions.AUTH_PARAMS))
+    keysToHideInLog: Set[String] = Set(PulsarOptions.AuthParams))
   extends Logging {
 
   private val map = new ju.HashMap[String, Object](pulsarParams.asJava)

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarMetadataReader.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarMetadataReader.scala
@@ -13,19 +13,20 @@
  */
 package org.apache.spark.sql.pulsar
 
-import java.{util => ju}
-import java.io.Closeable
-import java.util.{Optional, UUID}
-import java.util.concurrent.TimeUnit
-import java.util.regex.Pattern
 import org.apache.pulsar.client.admin.{PulsarAdmin, PulsarAdminException}
-import org.apache.pulsar.client.api.{Message, MessageId, PulsarClient, SubscriptionInitialPosition, SubscriptionType}
+import org.apache.pulsar.client.api.{Message, MessageId, PulsarClient}
 import org.apache.pulsar.client.impl.schema.BytesSchema
 import org.apache.pulsar.common.naming.TopicName
 import org.apache.pulsar.common.schema.SchemaInfo
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.pulsar.PulsarOptions.{AuthParams, AuthPluginClassName, TlsAllowInsecureConnection, TlsHostnameVerificationEnable, TlsTrustCertsFilePath, TopicMulti, TopicOptionKeys, TopicPattern, TopicSingle}
+import org.apache.spark.sql.pulsar.PulsarOptions._
 import org.apache.spark.sql.types.StructType
+
+import java.io.Closeable
+import java.util.Optional
+import java.util.concurrent.TimeUnit
+import java.util.regex.Pattern
+import java.{util => ju}
 
 /**
  * A Helper class that responsible for:

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarMetadataReader.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarMetadataReader.scala
@@ -26,7 +26,7 @@ import org.apache.pulsar.common.naming.TopicName
 import org.apache.pulsar.common.schema.SchemaInfo
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.pulsar.PulsarOptions.{AUTH_PARAMS, AUTH_PLUGIN_CLASS_NAME, TLS_ALLOW_INSECURE_CONNECTION, TLS_HOSTNAME_VERIFICATION_ENABLE, TLS_TRUST_CERTS_FILE_PATH, TOPIC_OPTION_KEYS}
+import org.apache.spark.sql.pulsar.PulsarOptions.{AuthParams, AuthPluginClassName, TlsAllowInsecureConnection, TlsHostnameVerificationEnable, TlsTrustCertsFilePath, TopicOptionKeys}
 import org.apache.spark.sql.types.StructType
 
 /**
@@ -237,7 +237,7 @@ private[pulsar] case class PulsarMetadataReader(
   }
 
   private def getTopics(): Seq[String] = {
-    topics = caseInsensitiveParameters.find(x => TOPIC_OPTION_KEYS.contains(x._1)).get match {
+    topics = caseInsensitiveParameters.find(x => TopicOptionKeys.contains(x._1)).get match {
       case ("topic", value) =>
         TopicName.get(value).toString :: Nil
       case ("topics", value) =>
@@ -255,7 +255,7 @@ private[pulsar] case class PulsarMetadataReader(
       if (partNum == 0) {
         tp :: Nil
       } else {
-        (0 until partNum).map(tp + PulsarOptions.PARTITION_SUFFIX + _)
+        (0 until partNum).map(tp + PulsarOptions.PartitionSuffix + _)
       }
     }
     topicPartitions
@@ -306,7 +306,7 @@ private[pulsar] case class PulsarMetadataReader(
         assert(
           specified.keySet.subsetOf(topicPartitions.toSet),
           s"topics designated in startingOffsets/endingOffsets" +
-            s" should all appear in $TOPIC_OPTION_KEYS .\n" +
+            s" should all appear in $TopicOptionKeys .\n" +
             s"topics: $topicPartitions, topics in offsets: ${specified.keySet}"
         )
         val nonSpecifiedTopics = topicPartitions.toSet -- specified.keySet
@@ -326,7 +326,7 @@ private[pulsar] case class PulsarMetadataReader(
         assert(
           specified.keySet.subsetOf(topicPartitions.toSet),
           s"topics designated in startingTime" +
-            s" should all appear in $TOPIC_OPTION_KEYS .\n" +
+            s" should all appear in $TopicOptionKeys .\n" +
             s"topics: $topicPartitions, topics in startingTime: ${specified.keySet}"
         )
         val nonSpecifiedTopics = topicPartitions.toSet -- specified.keySet
@@ -358,7 +358,7 @@ private[pulsar] case class PulsarMetadataReader(
         assert(
           specified.keySet.subsetOf(topicPartitions.toSet),
           s"topics designated in startingOffsets/endingOffsets" +
-            s" should all appear in $TOPIC_OPTION_KEYS .\n" +
+            s" should all appear in $TopicOptionKeys .\n" +
             s"topics: $topicPartitions, topics in offsets: ${specified.keySet}"
         )
         val nonSpecifiedTopics = topicPartitions.toSet -- specified.keySet

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarMetadataReader.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarMetadataReader.scala
@@ -13,20 +13,21 @@
  */
 package org.apache.spark.sql.pulsar
 
-import org.apache.pulsar.client.admin.{PulsarAdmin, PulsarAdminException}
-import org.apache.pulsar.client.api.{Message, MessageId, PulsarClient}
-import org.apache.pulsar.client.impl.schema.BytesSchema
-import org.apache.pulsar.common.naming.TopicName
-import org.apache.pulsar.common.schema.SchemaInfo
-import org.apache.spark.internal.Logging
-import org.apache.spark.sql.pulsar.PulsarOptions._
-import org.apache.spark.sql.types.StructType
-
 import java.io.Closeable
 import java.util.Optional
 import java.util.concurrent.TimeUnit
 import java.util.regex.Pattern
 import java.{util => ju}
+
+import org.apache.pulsar.client.admin.{PulsarAdmin, PulsarAdminException}
+import org.apache.pulsar.client.api.{Message, MessageId, PulsarClient}
+import org.apache.pulsar.client.impl.schema.BytesSchema
+import org.apache.pulsar.common.naming.TopicName
+import org.apache.pulsar.common.schema.SchemaInfo
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.pulsar.PulsarOptions._
+import org.apache.spark.sql.types.StructType
 
 /**
  * A Helper class that responsible for:

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarMetadataReader.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarMetadataReader.scala
@@ -237,7 +237,8 @@ private[pulsar] case class PulsarMetadataReader(
   }
 
   private def getTopics(): Seq[String] = {
-    topics = caseInsensitiveParameters.filterKeys(x => TopicOptionKeys.contains(x)).toSeq.head match {
+    topics = caseInsensitiveParameters
+      .filterKeys(x => TopicOptionKeys.contains(x)).toSeq.head match {
       case ("topic", value) =>
         TopicName.get(value).toString :: Nil
       case ("topics", value) =>

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarMetadataReader.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarMetadataReader.scala
@@ -14,10 +14,10 @@
 package org.apache.spark.sql.pulsar
 
 import java.io.Closeable
+import java.{util => ju}
 import java.util.Optional
 import java.util.concurrent.TimeUnit
 import java.util.regex.Pattern
-import java.{util => ju}
 
 import org.apache.pulsar.client.admin.{PulsarAdmin, PulsarAdminException}
 import org.apache.pulsar.client.api.{Message, MessageId, PulsarClient}

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarMetadataReader.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarMetadataReader.scala
@@ -13,8 +13,8 @@
  */
 package org.apache.spark.sql.pulsar
 
-import java.io.Closeable
 import java.{util => ju}
+import java.io.Closeable
 import java.util.Optional
 import java.util.concurrent.TimeUnit
 import java.util.regex.Pattern

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarMetadataReader.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarMetadataReader.scala
@@ -237,7 +237,7 @@ private[pulsar] case class PulsarMetadataReader(
   }
 
   private def getTopics(): Seq[String] = {
-    topics = caseInsensitiveParameters.find(x => TopicOptionKeys.contains(x._1)).get match {
+    topics = caseInsensitiveParameters.filterKeys(x => TopicOptionKeys.contains(x)).toSeq.head match {
       case ("topic", value) =>
         TopicName.get(value).toString :: Nil
       case ("topics", value) =>

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarMetadataReader.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarMetadataReader.scala
@@ -18,15 +18,13 @@ import java.io.Closeable
 import java.util.{Optional, UUID}
 import java.util.concurrent.TimeUnit
 import java.util.regex.Pattern
-
 import org.apache.pulsar.client.admin.{PulsarAdmin, PulsarAdminException}
 import org.apache.pulsar.client.api.{Message, MessageId, PulsarClient, SubscriptionInitialPosition, SubscriptionType}
 import org.apache.pulsar.client.impl.schema.BytesSchema
 import org.apache.pulsar.common.naming.TopicName
 import org.apache.pulsar.common.schema.SchemaInfo
-
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.pulsar.PulsarOptions.{AuthParams, AuthPluginClassName, TlsAllowInsecureConnection, TlsHostnameVerificationEnable, TlsTrustCertsFilePath, TopicOptionKeys}
+import org.apache.spark.sql.pulsar.PulsarOptions.{AuthParams, AuthPluginClassName, TlsAllowInsecureConnection, TlsHostnameVerificationEnable, TlsTrustCertsFilePath, TopicMulti, TopicOptionKeys, TopicPattern, TopicSingle}
 import org.apache.spark.sql.types.StructType
 
 /**
@@ -71,7 +69,7 @@ private[pulsar] case class PulsarMetadataReader(
         try {
           admin.topics().createSubscription(tp, s"$driverGroupIdPrefix-$tp", umid.mid)
         } catch {
-          case e: PulsarAdminException.ConnectException =>
+          case _: PulsarAdminException.ConflictException =>
             log.info("Subscription already exists, resetting the cursor to given offset")
             admin.topics().resetCursor(tp, s"$driverGroupIdPrefix-$tp", umid.mid)
           case e: Throwable =>
@@ -85,28 +83,28 @@ private[pulsar] case class PulsarMetadataReader(
   def setupCursorByTime(time: SpecificPulsarStartingTime): Unit = {
     time.topicTimes.foreach {
       case (tp, time) =>
-        if (time < 0) {
-          throw new RuntimeException(s"Invalid starting time for $tp: $time")
+        val msgID = time match {
+          case PulsarProvider.EARLIEST_TIME => MessageId.earliest
+          case PulsarProvider.LATEST_TIME => MessageId.latest
+          case t if t >= 0 => MessageId.latest
+          case _ => throw new RuntimeException(s"Invalid starting time for $tp: $time")
         }
 
         // setup the subscription
-        val msgID = if (time == PulsarProvider.EARLIEST_TIME) MessageId.earliest
-                    else MessageId.latest
         try {
           admin.topics().createSubscription(tp, s"$driverGroupIdPrefix-$tp", msgID)
         } catch {
           case _: PulsarAdminException.ConflictException =>
             log.info("subscription already exists, resetting the cursor to given offset")
+            time match {
+              case PulsarProvider.EARLIEST_TIME | PulsarProvider.LATEST_TIME =>
+                admin.topics().resetCursor(tp, s"$driverGroupIdPrefix-$tp", msgID)
+              case _ =>
+                admin.topics().resetCursor(tp, s"$driverGroupIdPrefix-$tp", time)
+            }
           case e: Throwable =>
             throw new RuntimeException(
               s"Failed to setup cursor for ${TopicName.get(tp).toString}", e)
-        }
-
-        // adjust subscription position
-        if (time == PulsarProvider.EARLIEST_TIME || time == PulsarProvider.LATEST_TIME) {
-          admin.topics().resetCursor(tp, s"$driverGroupIdPrefix-$tp", msgID)
-        } else {
-          admin.topics().resetCursor(tp, s"$driverGroupIdPrefix-$tp", time)
         }
     }
   }
@@ -237,16 +235,17 @@ private[pulsar] case class PulsarMetadataReader(
   }
 
   private def getTopics(): Seq[String] = {
-    topics = caseInsensitiveParameters
-      .filterKeys(x => TopicOptionKeys.contains(x)).toSeq.head match {
-      case ("topic", value) =>
+    val topics = caseInsensitiveParameters.find({case (key, _) => TopicOptionKeys.contains(key)})
+    topics match {
+      case Some((TopicSingle, value)) =>
         TopicName.get(value).toString :: Nil
-      case ("topics", value) =>
+      case Some((TopicMulti, value)) =>
         value.split(",").map(_.trim).filter(_.nonEmpty).map(TopicName.get(_).toString)
-      case ("topicspattern", value) =>
+      case Some((TopicPattern, value)) =>
         getTopics(value)
+      case None =>
+        throw new RuntimeException("Failed to get topics from configurations")
     }
-    topics
   }
 
   private def getTopicPartitions(): Seq[String] = {

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarOptions.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarOptions.scala
@@ -44,6 +44,7 @@ private[pulsar] object PulsarOptions {
   val STARTING_OFFSETS_OPTION_KEY = "startingoffsets"
   val STARTING_TIME = "startingtime"
   val ENDING_OFFSETS_OPTION_KEY = "endingoffsets"
+  val SUBSCRIPTION_PREFIX = "subscriptionPrefix"
 
   val POLL_TIMEOUT_MS = "polltimeoutms"
   val FAIL_ON_DATA_LOSS_OPTION_KEY = "failondataloss"

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarOptions.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarOptions.scala
@@ -19,45 +19,44 @@ import org.apache.pulsar.common.naming.TopicName
 private[pulsar] object PulsarOptions {
 
   // option key prefix for different modules
-  val PULSAR_ADMIN_OPTION_KEY_PREFIX = "pulsar.admin."
-  val PULSAR_CLIENT_OPTION_KEY_PREFIX = "pulsar.client."
-  val PULSAR_PRODUCER_OPTION_KEY_PREFIX = "pulsar.producer."
-  val PULSAR_CONSUMER_OPTION_KEY_PREFIX = "pulsar.consumer."
-  val PULSAR_READER_OPTION_KEY_PREFIX = "pulsar.reader."
+  val PulsarAdminOptionKeyPrefix = "pulsar.admin."
+  val PulsarClientOptionKeyPrefix = "pulsar.client."
+  val PulsarProducerOptionKeyPrefix = "pulsar.producer."
+  val PulsarConsumerOptionKeyPrefix = "pulsar.consumer."
+  val PulsarReaderOptionKeyPrefix = "pulsar.reader."
 
   // options
 
-  val TOPIC_SINGLE = "topic"
-  val TOPIC_MULTI = "topics"
-  val TOPIC_PATTERN = "topicspattern"
+  val TopicSingle = "topic"
+  val TopicMulti = "topics"
+  val TopicPattern = "topicspattern"
 
-  val PARTITION_SUFFIX = TopicName.PARTITIONED_TOPIC_SUFFIX
+  val PartitionSuffix: String = TopicName.PARTITIONED_TOPIC_SUFFIX
 
-  val TOPIC_OPTION_KEYS = Set(
-    TOPIC_SINGLE,
-    TOPIC_MULTI,
-    TOPIC_PATTERN
+  val TopicOptionKeys = Set(
+    TopicSingle,
+    TopicMulti,
+    TopicPattern
   )
 
-  val SERVICE_URL_OPTION_KEY = "service.url"
-  val ADMIN_URL_OPTION_KEY = "admin.url"
-  val STARTING_OFFSETS_OPTION_KEY = "startingoffsets"
-  val STARTING_TIME = "startingtime"
-  val ENDING_OFFSETS_OPTION_KEY = "endingoffsets"
-  val SUBSCRIPTION_PREFIX = "subscriptionprefix"
+  val ServiceUrlOptionKey = "service.url"
+  val AdminUrlOptionKey = "admin.url"
+  val StartingOffsetsOptionKey = "startingoffsets"
+  val StartingTime = "startingtime"
+  val EndingOffsetsOptionKey = "endingoffsets"
+  val SubscriptionPrefix = "subscriptionprefix"
 
-  val POLL_TIMEOUT_MS = "polltimeoutms"
-  val FAIL_ON_DATA_LOSS_OPTION_KEY = "failondataloss"
+  val PollTimeoutMS = "polltimeoutms"
+  val FailOnDataLossOptionKey = "failondataloss"
 
-  val AUTH_PLUGIN_CLASS_NAME = "authPluginClassName"
-  val AUTH_PARAMS = "authParams"
-  val TLS_TRUST_CERTS_FILE_PATH = "tlsTrustCertsFilePath"
-  val TLS_ALLOW_INSECURE_CONNECTION = "tlsAllowInsecureConnection"
-  val USE_TLS = "useTls"
-  val TLS_HOSTNAME_VERIFICATION_ENABLE = "tlsHostnameVerificationEnable"
+  val AuthPluginClassName = "authPluginClassName"
+  val AuthParams = "authParams"
+  val TlsTrustCertsFilePath = "tlsTrustCertsFilePath"
+  val TlsAllowInsecureConnection = "tlsAllowInsecureConnection"
+  val UseTls = "useTls"
+  val TlsHostnameVerificationEnable = "tlsHostnameVerificationEnable"
 
-
-  val INSTRUCTION_FOR_FAIL_ON_DATA_LOSS_FALSE =
+  val InstructionForFailOnDataLossFalse: String =
     """
       |Some data may have been lost because they are not available in Pulsar any more; either the
       | data was aged out by Pulsar or the topic may have been deleted before all the data in the
@@ -65,7 +64,7 @@ private[pulsar] object PulsarOptions {
       | option "failOnDataLoss" to "true".
     """.stripMargin
 
-  val INSTRUCTION_FOR_FAIL_ON_DATA_LOSS_TRUE =
+  val InstructionForFailOnDataLossTrue: String =
     """
       |Some data may have been lost because they are not available in Pulsar any more; either the
       | data was aged out by Pulsar or the topic may have been deleted before all the data in the
@@ -73,22 +72,22 @@ private[pulsar] object PulsarOptions {
       | source option "failOnDataLoss" to "false".
     """.stripMargin
 
-  val TOPIC_SCHEMA_CLASS_OPTION_KEY = "topic.schema.class"
+  val TopicSchemaClassOptionKey = "topic.schema.class"
 
-  val FILTERED_KEYS: Set[String] =
-    Set(TOPIC_SINGLE, SERVICE_URL_OPTION_KEY, TOPIC_SCHEMA_CLASS_OPTION_KEY)
+  val FilteredKeys: Set[String] =
+    Set(TopicSingle, ServiceUrlOptionKey, TopicSchemaClassOptionKey)
 
-  val TOPIC_ATTRIBUTE_NAME: String = "__topic"
-  val KEY_ATTRIBUTE_NAME: String = "__key"
-  val MESSAGE_ID_NAME: String = "__messageId"
-  val PUBLISH_TIME_NAME: String = "__publishTime"
-  val EVENT_TIME_NAME: String = "__eventTime"
+  val TopicAttributeName: String = "__topic"
+  val KeyAttributeName: String = "__key"
+  val MessageIdName: String = "__messageId"
+  val PublishTimeName: String = "__publishTime"
+  val EventTimeName: String = "__eventTime"
 
-  val META_FIELD_NAMES = Set(
-    TOPIC_ATTRIBUTE_NAME,
-    KEY_ATTRIBUTE_NAME,
-    MESSAGE_ID_NAME,
-    PUBLISH_TIME_NAME,
-    EVENT_TIME_NAME
+  val MetaFieldNames = Set(
+    TopicAttributeName,
+    KeyAttributeName,
+    MessageIdName,
+    PublishTimeName,
+    EventTimeName
   )
 }

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarOptions.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarOptions.scala
@@ -44,7 +44,7 @@ private[pulsar] object PulsarOptions {
   val STARTING_OFFSETS_OPTION_KEY = "startingoffsets"
   val STARTING_TIME = "startingtime"
   val ENDING_OFFSETS_OPTION_KEY = "endingoffsets"
-  val SUBSCRIPTION_PREFIX = "subscriptionPrefix"
+  val SUBSCRIPTION_PREFIX = "subscriptionprefix"
 
   val POLL_TIMEOUT_MS = "polltimeoutms"
   val FAIL_ON_DATA_LOSS_OPTION_KEY = "failondataloss"

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarProvider.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarProvider.scala
@@ -354,11 +354,11 @@ private[pulsar] object PulsarProvider extends Logging {
   }
 
   private def getServiceUrl(parameters: Map[String, String]): String = {
-    parameters.get(ServiceUrlOptionKey).get
+    parameters(ServiceUrlOptionKey)
   }
 
   private def getAdminUrl(parameters: Map[String, String]): String = {
-    parameters.get(AdminUrlOptionKey).get
+    parameters(AdminUrlOptionKey)
   }
 
   private def failOnDataLoss(caseInsensitiveParams: Map[String, String]): Boolean =
@@ -390,7 +390,7 @@ private[pulsar] object PulsarProvider extends Logging {
         "You should specify topic(s) using one of the topic options: "
           + TopicOptionKeys.mkString(", "))
     }
-    caseInsensitiveParams.find(x => TopicOptionKeys.contains(x._1)).get match {
+    topicOptions.head match {
       case ("topic", value) =>
         if (value.contains(",")) {
           throw new IllegalArgumentException(
@@ -407,7 +407,7 @@ private[pulsar] object PulsarProvider extends Logging {
         }
 
       case ("topicspattern", value) =>
-        if (value.trim.length == 0) {
+        if (value.trim.isEmpty) {
           throw new IllegalArgumentException("TopicsPattern is empty")
         }
     }

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarProvider.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarProvider.scala
@@ -142,7 +142,7 @@ private[pulsar] class PulsarProvider
 
       val endingOffset =
         reader.offsetForEachTopic(
-          caseInsensitiveParams, ENDING_OFFSETS_OPTION_KEY, LatestOffset)
+          caseInsensitiveParams, EndingOffsetsOptionKey, LatestOffset)
 
       val pulsarSchema = reader.getPulsarSchema()
       val schema = SchemaUtils.pulsarSourceSchema(pulsarSchema)
@@ -242,9 +242,9 @@ private[pulsar] object PulsarProvider extends Logging {
 
   private def getClientParams(parameters: Map[String, String]): Map[String, String] = {
     val lowercaseKeyMap = parameters.keySet
-      .filter(_.startsWith(PULSAR_CLIENT_OPTION_KEY_PREFIX))
+      .filter(_.startsWith(PulsarClientOptionKeyPrefix))
       .map { k =>
-        k.drop(PULSAR_CLIENT_OPTION_KEY_PREFIX.length).toString -> parameters(k)
+        k.drop(PulsarClientOptionKeyPrefix.length).toString -> parameters(k)
       }
       .toMap
     lowercaseKeyMap.map { case (k, v) =>
@@ -254,15 +254,15 @@ private[pulsar] object PulsarProvider extends Logging {
   }
 
   private def getProducerParams(parameters: Map[String, String]): Map[String, String] = {
-    getModuleParams(parameters, PULSAR_PRODUCER_OPTION_KEY_PREFIX, producerConfKeys)
+    getModuleParams(parameters, PulsarProducerOptionKeyPrefix, producerConfKeys)
   }
 
   private def getReaderParams(parameters: Map[String, String]): Map[String, String] = {
-    getModuleParams(parameters, PULSAR_READER_OPTION_KEY_PREFIX, readerConfKeys)
+    getModuleParams(parameters, PulsarReaderOptionKeyPrefix, readerConfKeys)
   }
 
   private def getAdminParams(parameters: Map[String, String]): Map[String, String] = {
-    getModuleParams(parameters, PULSAR_ADMIN_OPTION_KEY_PREFIX, clientConfKeys)
+    getModuleParams(parameters, PulsarAdminOptionKeyPrefix, clientConfKeys)
   }
 
   private def getModuleParams(
@@ -289,13 +289,13 @@ private[pulsar] object PulsarProvider extends Logging {
       params: Map[String, String],
       defaultOffsets: PulsarOffset): PulsarOffset = {
 
-    val startingOffsets = params.get(STARTING_OFFSETS_OPTION_KEY).map(_.trim)
-    val startingTime = params.get(STARTING_TIME).map(_.trim)
+    val startingOffsets = params.get(StartingOffsetsOptionKey).map(_.trim)
+    val startingTime = params.get(StartingTime).map(_.trim)
 
     if (startingOffsets.isDefined && startingTime.isDefined) {
       throw new IllegalArgumentException(
         "You can only specify starting position through " +
-          s"either $STARTING_OFFSETS_OPTION_KEY or $STARTING_TIME, not both.")
+          s"either $StartingOffsetsOptionKey or $StartingTime, not both.")
     }
 
     val result = if (startingOffsets.isDefined) {
@@ -350,47 +350,47 @@ private[pulsar] object PulsarProvider extends Logging {
   private def getSubscriptionPrefix(parameters: Map[String, String],
                                     isBatch: Boolean = false): String = {
     val defaultPrefix = if (isBatch) "spark-pulsar-batch" else "spar-pulsar"
-    parameters.getOrElse(SUBSCRIPTION_PREFIX, s"$defaultPrefix-${UUID.randomUUID}")
+    parameters.getOrElse(SubscriptionPrefix, s"$defaultPrefix-${UUID.randomUUID}")
   }
 
   private def getServiceUrl(parameters: Map[String, String]): String = {
-    parameters.get(SERVICE_URL_OPTION_KEY).get
+    parameters.get(ServiceUrlOptionKey).get
   }
 
   private def getAdminUrl(parameters: Map[String, String]): String = {
-    parameters.get(ADMIN_URL_OPTION_KEY).get
+    parameters.get(AdminUrlOptionKey).get
   }
 
   private def failOnDataLoss(caseInsensitiveParams: Map[String, String]): Boolean =
-    caseInsensitiveParams.getOrElse(FAIL_ON_DATA_LOSS_OPTION_KEY, "false").toBoolean
+    caseInsensitiveParams.getOrElse(FailOnDataLossOptionKey, "false").toBoolean
 
   private def pollTimeoutMs(caseInsensitiveParams: Map[String, String]): Int =
     caseInsensitiveParams
       .getOrElse(
-        PulsarOptions.POLL_TIMEOUT_MS,
+        PulsarOptions.PollTimeoutMS,
         (SparkEnv.get.conf.getTimeAsSeconds("spark.network.timeout", "120s") * 1000).toString)
       .toInt
 
   private def validateGeneralOptions(
       caseInsensitiveParams: Map[String, String]): Map[String, String] = {
-    if (!caseInsensitiveParams.contains(SERVICE_URL_OPTION_KEY)) {
-      throw new IllegalArgumentException(s"$SERVICE_URL_OPTION_KEY must be specified")
+    if (!caseInsensitiveParams.contains(ServiceUrlOptionKey)) {
+      throw new IllegalArgumentException(s"$ServiceUrlOptionKey must be specified")
     }
 
-    if (!caseInsensitiveParams.contains(ADMIN_URL_OPTION_KEY)) {
-      throw new IllegalArgumentException(s"$ADMIN_URL_OPTION_KEY must be specified")
+    if (!caseInsensitiveParams.contains(AdminUrlOptionKey)) {
+      throw new IllegalArgumentException(s"$AdminUrlOptionKey must be specified")
     }
 
     // validate topic options
     val topicOptions = caseInsensitiveParams.filter {
-      case (k, _) => TOPIC_OPTION_KEYS.contains(k)
+      case (k, _) => TopicOptionKeys.contains(k)
     }.toSeq
     if (topicOptions.isEmpty || topicOptions.size > 1) {
       throw new IllegalArgumentException(
         "You should specify topic(s) using one of the topic options: "
-          + TOPIC_OPTION_KEYS.mkString(", "))
+          + TopicOptionKeys.mkString(", "))
     }
-    caseInsensitiveParams.find(x => TOPIC_OPTION_KEYS.contains(x._1)).get match {
+    caseInsensitiveParams.find(x => TopicOptionKeys.contains(x._1)).get match {
       case ("topic", value) =>
         if (value.contains(",")) {
           throw new IllegalArgumentException(
@@ -417,7 +417,7 @@ private[pulsar] object PulsarProvider extends Logging {
   private def validateStreamOptions(parameters: Map[String, String]): Map[String, String] = {
     val caseInsensitiveParams = parameters.map { case (k, v) => (k.toLowerCase(Locale.ROOT), v) }
     caseInsensitiveParams
-      .get(ENDING_OFFSETS_OPTION_KEY)
+      .get(EndingOffsetsOptionKey)
       .map(_ =>
         throw new IllegalArgumentException("ending offset not valid in streaming queries"))
 
@@ -426,7 +426,7 @@ private[pulsar] object PulsarProvider extends Logging {
 
   private def validateBatchOptions(parameters: Map[String, String]): Map[String, String] = {
     val caseInsensitiveParams = parameters.map { case (k, v) => (k.toLowerCase(Locale.ROOT), v) }
-    getPulsarOffset(caseInsensitiveParams, STARTING_OFFSETS_OPTION_KEY, EarliestOffset) match {
+    getPulsarOffset(caseInsensitiveParams, StartingOffsetsOptionKey, EarliestOffset) match {
       case EarliestOffset => // good to go
       case LatestOffset =>
         throw new IllegalArgumentException(
@@ -442,7 +442,7 @@ private[pulsar] object PulsarProvider extends Logging {
         }
     }
 
-    getPulsarOffset(caseInsensitiveParams, ENDING_OFFSETS_OPTION_KEY, LatestOffset) match {
+    getPulsarOffset(caseInsensitiveParams, EndingOffsetsOptionKey, LatestOffset) match {
       case EarliestOffset =>
         throw new IllegalArgumentException(
           "ending offset can't be earliest " +
@@ -464,21 +464,21 @@ private[pulsar] object PulsarProvider extends Logging {
   private def validateSinkOptions(parameters: Map[String, String]): Map[String, String] = {
     val caseInsensitiveParams = parameters.map { case (k, v) => (k.toLowerCase(Locale.ROOT), v) }
 
-    if (!caseInsensitiveParams.contains(SERVICE_URL_OPTION_KEY)) {
-      throw new IllegalArgumentException(s"$SERVICE_URL_OPTION_KEY must be specified")
+    if (!caseInsensitiveParams.contains(ServiceUrlOptionKey)) {
+      throw new IllegalArgumentException(s"$ServiceUrlOptionKey must be specified")
     }
 
-    if (!caseInsensitiveParams.contains(ADMIN_URL_OPTION_KEY)) {
-      throw new IllegalArgumentException(s"$ADMIN_URL_OPTION_KEY must be specified")
+    if (!caseInsensitiveParams.contains(AdminUrlOptionKey)) {
+      throw new IllegalArgumentException(s"$AdminUrlOptionKey must be specified")
     }
 
     val topicOptions =
-      caseInsensitiveParams.filter { case (k, _) => TOPIC_OPTION_KEYS.contains(k) }.toSeq.toMap
-    if (topicOptions.size > 1 || topicOptions.contains(TOPIC_MULTI) || topicOptions.contains(
-          TOPIC_PATTERN)) {
+      caseInsensitiveParams.filter { case (k, _) => TopicOptionKeys.contains(k) }.toSeq.toMap
+    if (topicOptions.size > 1 || topicOptions.contains(TopicMulti) || topicOptions.contains(
+          TopicPattern)) {
       throw new IllegalArgumentException(
         "Currently, we only support specify single topic through option, " +
-          s"use '$TOPIC_SINGLE' to specify it.")
+          s"use '$TopicSingle' to specify it.")
     }
 
     caseInsensitiveParams
@@ -491,7 +491,7 @@ private[pulsar] object PulsarProvider extends Logging {
     val adminUrl = getAdminUrl(parameters)
 
     var clientParams = getClientParams(parameters)
-    clientParams += (SERVICE_URL_OPTION_KEY -> serviceUrl)
+    clientParams += (ServiceUrlOptionKey -> serviceUrl)
     val readerParams = getReaderParams(parameters)
     val adminParams = Option(getAdminParams(parameters))
       .filter(_.nonEmpty)
@@ -513,10 +513,10 @@ private[pulsar] object PulsarProvider extends Logging {
     val adminUrl = getAdminUrl(parameters)
 
     var clientParams = getClientParams(parameters)
-    clientParams += (SERVICE_URL_OPTION_KEY -> serviceUrl)
+    clientParams += (ServiceUrlOptionKey -> serviceUrl)
     val producerParams = getProducerParams(parameters)
 
-    val topic = parameters.get(TOPIC_SINGLE).map(_.trim).map(TopicName.get(_).toString)
+    val topic = parameters.get(TopicSingle).map(_.trim).map(TopicName.get(_).toString)
 
     (
       paramsToPulsarConf("pulsar.client", clientParams),

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarProvider.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarProvider.scala
@@ -83,7 +83,7 @@ private[pulsar] class PulsarProvider
     val (clientConfig, readerConfig, adminClientConfig, serviceUrl, adminUrl) =
       prepareConfForReader(parameters)
 
-    val subscriptionNamePrefix = s"spark-pulsar-${UUID.randomUUID}-${metadataPath.hashCode}"
+    val subscriptionNamePrefix = getSubscriptionPrefix(parameters)
     val metadataReader = new PulsarMetadataReader(
       serviceUrl,
       adminUrl,
@@ -119,7 +119,7 @@ private[pulsar] class PulsarProvider
       parameters: Map[String, String]): BaseRelation = {
     val caseInsensitiveParams = validateBatchOptions(parameters)
 
-    val subscriptionNamePrefix = s"spark-pulsar-batch-${UUID.randomUUID}"
+    val subscriptionNamePrefix = getSubscriptionPrefix(parameters, isBatch = true)
 
     val (clientConfig, readerConfig, adminClientConfig, serviceUrl, adminUrl) =
       prepareConfForReader(parameters)
@@ -345,6 +345,12 @@ private[pulsar] object PulsarProvider extends Logging {
 
   def paramsToPulsarConf(module: String, params: Map[String, String]): ju.Map[String, Object] = {
     PulsarConfigUpdater(module, params).rebuild()
+  }
+
+  private def getSubscriptionPrefix(parameters: Map[String, String],
+                                    isBatch: Boolean = false): String = {
+    val defaultPrefix = if (isBatch) "spark-pulsar-batch" else "spar-pulsar"
+    parameters.getOrElse(SUBSCRIPTION_PREFIX, s"$defaultPrefix-${UUID.randomUUID}")
   }
 
   private def getServiceUrl(parameters: Map[String, String]): String = {

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarSinks.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarSinks.scala
@@ -78,13 +78,13 @@ private[pulsar] object PulsarSinks extends Logging {
 
   def validateQuery(schema: Seq[Attribute], topic: Option[String]): Unit = {
     schema
-      .find(_.name == TOPIC_ATTRIBUTE_NAME)
+      .find(_.name == TopicAttributeName)
       .getOrElse(
         if (topic.isEmpty) {
           throw new AnalysisException(
             s"topic option required when no " +
-              s"'$TOPIC_ATTRIBUTE_NAME' attribute is present. Use the " +
-              s"$TOPIC_SINGLE option for setting a topic.")
+              s"'$TopicAttributeName' attribute is present. Use the " +
+              s"$TopicSingle option for setting a topic.")
         } else {
           Literal(topic.get, StringType)
         }
@@ -96,7 +96,7 @@ private[pulsar] object PulsarSinks extends Logging {
     }
 
     schema
-      .find(_.name == PulsarOptions.KEY_ATTRIBUTE_NAME)
+      .find(_.name == PulsarOptions.KeyAttributeName)
       .getOrElse(
         Literal(null, StringType)
       )
@@ -104,12 +104,12 @@ private[pulsar] object PulsarSinks extends Logging {
       case StringType | BinaryType => // good
       case _ =>
         throw new AnalysisException(
-          s"${PulsarOptions.KEY_ATTRIBUTE_NAME} attribute type " +
+          s"${PulsarOptions.KeyAttributeName} attribute type " +
             s"must be a ${StringType.catalogString} or ${BinaryType.catalogString}")
     }
 
     schema
-      .find(_.name == PulsarOptions.EVENT_TIME_NAME)
+      .find(_.name == PulsarOptions.EventTimeName)
       .getOrElse(
         Literal(null, LongType)
       )
@@ -117,15 +117,15 @@ private[pulsar] object PulsarSinks extends Logging {
       case LongType | TimestampType => // good
       case _ =>
         throw new AnalysisException(
-          s"${PulsarOptions.EVENT_TIME_NAME} attribute type " +
+          s"${PulsarOptions.EventTimeName} attribute type " +
             s"must be a ${LongType.catalogString} or ${TimestampType.catalogString}")
     }
 
     schema
       .find(
         a =>
-          a.name == PulsarOptions.MESSAGE_ID_NAME ||
-            a.name == PulsarOptions.PUBLISH_TIME_NAME)
+          a.name == PulsarOptions.MessageIdName ||
+            a.name == PulsarOptions.PublishTimeName)
       .map(a =>
         logWarning(s"${a.name} attribute exists in schema," +
           "it's reserved by Pulsar Source and generated automatically by pulsar for each record." +

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarSinks.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarSinks.scala
@@ -132,7 +132,7 @@ private[pulsar] object PulsarSinks extends Logging {
           "Choose another name if you want to keep this field or it will be ignored by pulsar."))
 
     val valuesExpression =
-      schema.filter(n => !PulsarOptions.META_FIELD_NAMES.contains(n.name))
+      schema.filter(n => !PulsarOptions.MetaFieldNames.contains(n.name))
 
     if (valuesExpression.length == 0) {
       throw new AnalysisException("Schema should have at least one non-key/non-topic field")

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarSources.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarSources.scala
@@ -60,9 +60,9 @@ private[pulsar] object PulsarSourceUtils extends Logging {
    */
   def reportDataLossFunc(failOnDataLoss: Boolean): (String) => Unit = { (message: String) =>
     if (failOnDataLoss) {
-      throw new IllegalStateException(message + s". $INSTRUCTION_FOR_FAIL_ON_DATA_LOSS_TRUE")
+      throw new IllegalStateException(message + s". $InstructionForFailOnDataLossTrue")
     } else {
-      logWarning(message + s". $INSTRUCTION_FOR_FAIL_ON_DATA_LOSS_FALSE")
+      logWarning(message + s". $InstructionForFailOnDataLossFalse")
     }
   }
 

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarWriteTask.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarWriteTask.scala
@@ -66,41 +66,41 @@ private[pulsar] abstract class PulsarRowWriter(
     val topicExpression = topic
       .map(Literal(_))
       .orElse {
-        inputSchema.find(_.name == TOPIC_ATTRIBUTE_NAME)
+        inputSchema.find(_.name == TopicAttributeName)
       }
       .getOrElse {
         throw new IllegalStateException(
           s"topic option required when no " +
-            s"'$TOPIC_ATTRIBUTE_NAME' attribute is present")
+            s"'$TopicAttributeName' attribute is present")
       }
     topicExpression.dataType match {
       case StringType => // good
       case t =>
         throw new IllegalStateException(
-          TOPIC_ATTRIBUTE_NAME +
-            s"attribute unsupported type $t. $TOPIC_ATTRIBUTE_NAME " +
+          TopicAttributeName +
+            s"attribute unsupported type $t. $TopicAttributeName " +
             s"must be a ${StringType.catalogString}")
     }
 
     val keyExpression = inputSchema
-      .find(_.name == KEY_ATTRIBUTE_NAME)
+      .find(_.name == KeyAttributeName)
       .getOrElse(Literal(null, BinaryType))
     keyExpression.dataType match {
       case StringType | BinaryType => // good
       case t =>
         throw new IllegalStateException(
-          KEY_ATTRIBUTE_NAME +
+          KeyAttributeName +
             s"attribute unsupported type ${t.catalogString}")
     }
 
     val eventTimeExpression = inputSchema
-      .find(_.name == EVENT_TIME_NAME)
+      .find(_.name == EventTimeName)
       .getOrElse(Literal(null, LongType))
     eventTimeExpression.dataType match {
       case LongType | TimestampType => // good
       case t =>
         throw new IllegalStateException(
-          EVENT_TIME_NAME +
+          EventTimeName +
             s"attribute unsupported type ${t.catalogString}")
     }
 
@@ -182,7 +182,7 @@ private[pulsar] abstract class PulsarRowWriter(
     if (topic == null) {
       throw new NullPointerException(
         s"null topic present in the data. Use the " +
-          s"$TOPIC_SINGLE option for setting a topic.")
+          s"$TopicSingle option for setting a topic.")
     }
 
     val mb = getProducer(topic.toString).newMessage().value(value)

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarWriteTask.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarWriteTask.scala
@@ -109,7 +109,7 @@ private[pulsar] abstract class PulsarRowWriter(
       inputSchema)
 
     val valuesExpression =
-      inputSchema.filter(n => !PulsarOptions.META_FIELD_NAMES.contains(n.name))
+      inputSchema.filter(n => !PulsarOptions.MetaFieldNames.contains(n.name))
 
     val valueProj = UnsafeProjection.create(valuesExpression, inputSchema)
 

--- a/src/main/scala/org/apache/spark/sql/pulsar/SchemaUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/SchemaUtils.scala
@@ -383,11 +383,11 @@ private[pulsar] object SchemaUtils {
   import PulsarOptions._
 
   val metaDataFields: Seq[StructField] = Seq(
-    StructField(KEY_ATTRIBUTE_NAME, BinaryType),
-    StructField(TOPIC_ATTRIBUTE_NAME, StringType),
-    StructField(MESSAGE_ID_NAME, BinaryType),
-    StructField(PUBLISH_TIME_NAME, TimestampType),
-    StructField(EVENT_TIME_NAME, TimestampType)
+    StructField(KeyAttributeName, BinaryType),
+    StructField(TopicAttributeName, StringType),
+    StructField(MessageIdName, BinaryType),
+    StructField(PublishTimeName, TimestampType),
+    StructField(EventTimeName, TimestampType)
   )
 
 }


### PR DESCRIPTION
User can configure a desired subscription prefix name instead of randomly generated one for reading metadata from pulsar topics.

This change helps user reuse an existing subscription and avoid creating too many random subscriptions during job restarts.

Usage:
```
    val s = SparkSession.builder()
      .appName("sleep-task")
      .getOrCreate()
      .readStream
      .format("pulsar")
      .option("service.url", "pulsar://localhost:6650")
      .option("admin.url", "http://localhost:10080")
      .option("topic", "public/default/test")
      .option("subscriptionprefix", "nlu-test")
      .load()
```

Now the subscription can be checked with `stats` command.

```
➜  apache-pulsar-2.8.0 ./bin/pulsar-admin --admin-url "http://localhost:10080"  topics stats public/default/test-partition-1
{
  ....
  "subscriptions" : {
    "nlu-test-persistent://public/default/test-partition-1" : {
      "msgRateOut" : 0.0,
      "msgThroughputOut" : 0.0,
      "bytesOutCounter" : 0,
      "msgOutCounter" : 0,
      "msgRateRedeliver" : 0.0,
      "chunkedMessageRate" : 0,
      "msgBacklog" : 1,
       ....
    }
  },
  "replication" : { },
  "deduplicationStatus" : "Disabled",
  "nonContiguousDeletedMessagesRanges" : 0,
  "nonContiguousDeletedMessagesRangesSerializedSize" : 0
}
```




