### PR TITLE
bump pulsar client version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
 
     <!-- dependencies -->
     <!-- latest version from apache pulsar master -->
-    <pulsar.version>2.4.2</pulsar.version>
+    <pulsar.version>2.7.3</pulsar.version>
     <scala.version>2.12.10</scala.version>
     <scala.binary.version>2.12</scala.binary.version>
     <scalatest.version>3.2.2</scalatest.version>


### PR DESCRIPTION
Pulsar client 2.4.2 is released on 2019-12-04, which is pretty old.

This PR upgrade the pulsar client to 2.7.3.

Verified locally it can read data from pulsar successfully with auth turned on.

```
Batch: 10
-------------------------------------------
+--------------------+-----+--------------------+--------------------+--------------------+-----------+
|               value|__key|             __topic|         __messageId|       __publishTime|__eventTime|
+--------------------+-----+--------------------+--------------------+--------------------+-----------+
|[31 30 20 68 65 6...| null|persistent://publ...|[08 B3 A0 01 10 0...|2021-11-02 16:11:...|       null|
+--------------------+-----+--------------------+--------------------+--------------------+-----------+

```

