### PR TITLE
fix getTopics

### DIFF
--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarMetadataReader.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarMetadataReader.scala
@@ -237,8 +237,9 @@ private[pulsar] case class PulsarMetadataReader(
   }
 
   private def getTopics(): Seq[String] = {
-    val topics = caseInsensitiveParameters.find({case (key, _) => TopicOptionKeys.contains(key)})
-    topics match {
+    val optionalTopics =
+      caseInsensitiveParameters.find({case (key, _) => TopicOptionKeys.contains(key)})
+    topics = optionalTopics match {
       case Some((TopicSingle, value)) =>
         TopicName.get(value).toString :: Nil
       case Some((TopicMulti, value)) =>
@@ -248,6 +249,7 @@ private[pulsar] case class PulsarMetadataReader(
       case None =>
         throw new RuntimeException("Failed to get topics from configurations")
     }
+    topics
   }
 
   private def getTopicPartitions(): Seq[String] = {

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarMetadataReader.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarMetadataReader.scala
@@ -236,7 +236,7 @@ private[pulsar] case class PulsarMetadataReader(
     }
   }
 
-  private def getTopics(): Seq[String] = {
+  private def getTopics(): Unit = {
     val optionalTopics =
       caseInsensitiveParameters.find({case (key, _) => TopicOptionKeys.contains(key)})
     topics = optionalTopics match {
@@ -249,7 +249,6 @@ private[pulsar] case class PulsarMetadataReader(
       case None =>
         throw new RuntimeException("Failed to get topics from configurations")
     }
-    topics
   }
 
   private def getTopicPartitions(): Seq[String] = {


### PR DESCRIPTION
User reported the NPE error for the release 3.1.1.2
```
Traceback (most recent call last):
  File "/Users/ashi/MyDev/workspace/src/post_call_etl_job/main_local.py", line 361, in <module>
    compute_df = pci.events_queueDF(spark, topic_compute, schema, partition_count)
  File "/Users/ashi/MyDev/workspace/src/post_call_etl_job/main_local.py", line 102, in events_queueDF
    .option("subscriptionprefix", "nlu-test") \
  File "/Users/ashi/MyDev/workspace/.venv/lib/python3.7/site-packages/pyspark/sql/streaming.py", line 482, in load
    return self._df(self._jreader.load())
  File "/Users/ashi/MyDev/workspace/.venv/lib/python3.7/site-packages/py4j/java_gateway.py", line 1305, in __call__
    answer, self.gateway_client, self.target_id, self.name)
  File "/Users/ashi/MyDev/workspace/.venv/lib/python3.7/site-packages/pyspark/sql/utils.py", line 111, in deco
    return f(*a, **kw)
  File "/Users/ashi/MyDev/workspace/.venv/lib/python3.7/site-packages/py4j/protocol.py", line 328, in get_return_value
    format(target_id, ".", name), value)
py4j.protocol.Py4JJavaError: An error occurred while calling o63.load.
: java.lang.NullPointerException
	at org.apache.spark.sql.pulsar.PulsarMetadataReader.getPulsarSchema(PulsarMetadataReader.scala:170)
	at org.apache.spark.sql.pulsar.PulsarMetadataReader.getSchema(PulsarMetadataReader.scala:164)
	at org.apache.spark.sql.pulsar.PulsarMetadataReader.getAndCheckCompatible(PulsarMetadataReader.scala:148)
	at org.apache.spark.sql.pulsar.PulsarProvider.$anonfun$sourceSchema$2(PulsarProvider.scala:71)
	at org.apache.spark.util.Utils$.tryWithResource(Utils.scala:2622)
	at org.apache.spark.sql.pulsar.PulsarProvider.sourceSchema(PulsarProvider.scala:70)
	at org.apache.spark.sql.execution.datasources.DataSource.sourceSchema(DataSource.scala:236)
	at org.apache.spark.sql.execution.datasources.DataSource.sourceInfo$lzycompute(DataSource.scala:117)
	at org.apache.spark.sql.execution.datasources.DataSource.sourceInfo(DataSource.scala:117)
	at org.apache.spark.sql.execution.streaming.StreamingRelation$.apply(StreamingRelation.scala:33)
	at org.apache.spark.sql.streaming.DataStreamReader.loadInternal(DataStreamReader.scala:219)
	at org.apache.spark.sql.streaming.DataStreamReader.load(DataStreamReader.scala:194)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at py4j.reflection.MethodInvoker.invoke(MethodInvoker.java:244)
	at py4j.reflection.ReflectionEngine.invoke(ReflectionEngine.java:357)
	at py4j.Gateway.invoke(Gateway.java:282)
	at py4j.commands.AbstractCommand.invokeMethod(AbstractCommand.java:132)
	at py4j.commands.CallCommand.execute(CallCommand.java:79)
	at py4j.GatewayConnection.run(GatewayConnection.java:238)
	at java.lang.Thread.run(Thread.java:748)
```

It turns out the `getTopics()` method should update the `topics` class field, but we accidentally shadows it with a local variable.