### PR TITLE
expose pulsar message properties as a metadata column

### DIFF
--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarOptions.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarOptions.scala
@@ -84,12 +84,14 @@ private[pulsar] object PulsarOptions {
   val MessageIdName: String = "__messageId"
   val PublishTimeName: String = "__publishTime"
   val EventTimeName: String = "__eventTime"
+  val MessagePropertiesName: String = "__messageProperties"
 
   val MetaFieldNames = Set(
     TopicAttributeName,
     KeyAttributeName,
     MessageIdName,
     PublishTimeName,
-    EventTimeName
+    EventTimeName,
+    MessagePropertiesName
   )
 }

--- a/src/main/scala/org/apache/spark/sql/pulsar/SchemaUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/SchemaUtils.scala
@@ -387,7 +387,8 @@ private[pulsar] object SchemaUtils {
     StructField(TopicAttributeName, StringType),
     StructField(MessageIdName, BinaryType),
     StructField(PublishTimeName, TimestampType),
-    StructField(EventTimeName, TimestampType)
+    StructField(EventTimeName, TimestampType),
+    StructField(MessagePropertiesName, MapType(StringType, StringType, valueContainsNull = true))
   )
 
 }


### PR DESCRIPTION
User needs to access  message properties to decide routing behavior. 
The properties of type Map<String, String> is exposed as MapData[StringType, StringType] in spark sql result.

Example output:
```
+---------+----------+-----+--------------------+--------------------+--------------------+--------------------+--------------------+--------------------+
|order_uid|product_id|total|               __key|             __topic|         __messageId|       __publishTime|         __eventTime| __messageProperties|
+---------+----------+-----+--------------------+--------------------+--------------------+--------------------+--------------------+--------------------+
|      105|       500|700.0|[63 61 2D 38 34 3...|persistent://publ...|[08 B5 DF 01 10 1...|2021-11-17 16:49:...|2021-11-17 16:49:...|{id -> 5, locatio...|
+---------+----------+-----+--------------------+--------------------+--------------------+--------------------+--------------------+--------------------+
```