### PR TITLE
remove bintary doc from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Build Status](https://jenkins.snio.xyz/buildStatus/icon?job=StreamNative%2Fpulsar-spark%2Fmaster)](https://jenkins.snio.xyz/job/StreamNative/job/pulsar-spark/job/master/)
 [![Version](https://img.shields.io/github/release/streamnative/pulsar-spark/all.svg)](https://github.com/streamnative/pulsar-spark/releases)
-[![Bintray](https://img.shields.io/badge/dynamic/json.svg?label=latest&query=name&style=flat-square&url=https%3A%2F%2Fapi.bintray.com%2Fpackages%2Fstreamnative%2Fmaven%2Fio.streamnative.pulsar-spark%2Fversions%2F_latest)](https://dl.bintray.com/streamnative/maven/io/streamnative/connectors/pulsar-spark-connector_2.11/)
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fstreamnative%2Fpulsar-spark.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fstreamnative%2Fpulsar-spark?ref=badge_shield)
@@ -27,22 +26,6 @@ For Scala/Java applications using SBT/Maven project definitions, link your appli
     artifactId = pulsar-spark-connector_{{SCALA_BINARY_VERSION}}
     version = {{PULSAR_SPARK_VERSION}}
 ```
-Currently, the artifact is available in [Bintray Maven repository of StreamNative]( https://dl.bintray.com/streamnative/maven).
-For Maven project, you can add the repository to your `pom.xml` as follows:
-```xml
-  <repositories>
-    <repository>
-      <id>central</id>
-      <layout>default</layout>
-      <url>https://repo1.maven.org/maven2</url>
-    </repository>
-    <repository>
-      <id>bintray-streamnative-maven</id>
-      <name>bintray</name>
-      <url>https://dl.bintray.com/streamnative/maven</url>
-    </repository>
-  </repositories>
-```
 
 ### Deploy
 
@@ -56,7 +39,6 @@ Example
 ```
 $ ./bin/spark-submit 
   --packages io.streamnative.connectors:pulsar-spark-connector_{{SCALA_BINARY_VERSION}}:{{PULSAR_SPARK_VERSION}}
-  --repositories https://dl.bintray.com/streamnative/maven
   ...
 ```
 
@@ -68,7 +50,6 @@ Example
 ```
 $ ./bin/spark-shell 
   --packages io.streamnative.connectors:pulsar-spark-connector_{{SCALA_BINARY_VERSION}}:{{PULSAR_SPARK_VERSION}}
-  --repositories https://dl.bintray.com/streamnative/maven
   ...
 ```
 


### PR DESCRIPTION
We publish artifacts into maven central now instead of bintary.
So remove the bintary related documentation.