### PR TITLE
[FEATURE] Add endingtime feature

### DIFF
--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarMetadataReader.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarMetadataReader.scala
@@ -434,9 +434,9 @@ private[pulsar] case class PulsarMetadataReader(
   }
 
   def fetchCurrentOffsets(
-                           time: SpecificPulsarTime,
-                           pollTimeoutMs: Int,
-                           reportDataLoss: String => Unit): Map[String, MessageId] = {
+      time: SpecificPulsarTime,
+      pollTimeoutMs: Int,
+      reportDataLoss: String => Unit): Map[String, MessageId] = {
 
     time.topicTimes.map { case (tp, time) =>
       val actualOffset =

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarOffset.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarOffset.scala
@@ -36,7 +36,7 @@ private[pulsar] case class SpecificPulsarOffset(topicOffsets: Map[String, Messag
   override val json = JsonUtils.topicOffsets(topicOffsets)
 }
 
-private[pulsar] case class SpecificPulsarStartingTime(topicTimes: Map[String, Long])
+private[pulsar] case class SpecificPulsarTime(topicTimes: Map[String, Long])
     extends Offset
     with PerTopicOffset {
 

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarOptions.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarOptions.scala
@@ -39,7 +39,10 @@ private[pulsar] object PulsarOptions {
   val AdminUrlOptionKey = "admin.url"
   val StartingOffsetsOptionKey = "startingoffsets"
   val StartingTime = "startingtime"
+  val EndingTime = "endingtime"
   val EndingOffsetsOptionKey = "endingoffsets"
+  val StartOptionKey = "startOptionKey"
+  val EndOptionKey = "endOptionKey"
   val SubscriptionPrefix = "subscriptionprefix"
   val PredefinedSubscription = "predefinedsubscription"
 


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #96

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

Sometimes we need to specify the start time and end time to pull a batch of data during the period, but currently only the startingtime can be specified.

### Modifications

<!-- Describe the modifications you've done. -->

At the beginning of the program, read through seek to the specified endingtime messageId.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [x] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->