### PR TITLE
fix: the subscriptionPrefix parameter does not take effect

### DIFF
--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarContinuousReader.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarContinuousReader.scala
@@ -240,6 +240,7 @@ class PulsarContinuousTopicReader(
   private val reader = CachedPulsarClient
     .getOrCreate(clientConf)
     .newReader(schema)
+    .subscriptionRolePrefix(subscriptionNamePrefix)
     .topic(topic)
     .startMessageId(startingOffsets)
     .startMessageIdInclusive()

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarMetadataReader.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarMetadataReader.scala
@@ -449,6 +449,7 @@ private[pulsar] case class PulsarMetadataReader(
           assert(time > 0, s"time less than 0: $time")
           val reader = client
             .newReader()
+            .subscriptionRolePrefix(driverGroupIdPrefix)
             .topic(tp)
             .startMessageId(MessageId.earliest)
             .startMessageIdInclusive()
@@ -464,6 +465,7 @@ private[pulsar] case class PulsarMetadataReader(
             reader.seek(time)
             var msg: Message[Array[Byte]] = null
             msg = reader.readNext(pollTimeoutMs, TimeUnit.MILLISECONDS)
+            reader.close()
             if (msg == null) {
               UserProvidedMessageId(MessageId.earliest)
             } else {
@@ -512,6 +514,7 @@ private[pulsar] case class PulsarMetadataReader(
       case _ =>
         val reader = client
           .newReader()
+          .subscriptionRolePrefix(driverGroupIdPrefix)
           .startMessageId(off)
           .startMessageIdInclusive()
           .topic(tp)

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarMicroBatchReader.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarMicroBatchReader.scala
@@ -210,6 +210,7 @@ case class PulsarMicroBatchInputPartitionReader(
   val reader = CachedPulsarClient
     .getOrCreate(clientConf)
     .newReader(schema)
+    .subscriptionRolePrefix(subscriptionNamePrefix)
     .startMessageId(start)
     .startMessageIdInclusive()
     .topic(tp)

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarOptions.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarOptions.scala
@@ -43,8 +43,8 @@ private[pulsar] object PulsarOptions {
   val StartingTime: String = "startingTime".toLowerCase(Locale.ROOT)
   val EndingTime: String = "endingTime".toLowerCase(Locale.ROOT)
   val EndingOffsetsOptionKey: String = "endingOffsets".toLowerCase(Locale.ROOT)
-  val StartOptionKey = "startOptionKey".toLowerCase(Locale.ROOT)
-  val EndOptionKey = "endOptionKey".toLowerCase(Locale.ROOT)
+  val StartOptionKey: String = "startOptionKey".toLowerCase(Locale.ROOT)
+  val EndOptionKey: String = "endOptionKey".toLowerCase(Locale.ROOT)
   val SubscriptionPrefix: String = "subscriptionPrefix".toLowerCase(Locale.ROOT)
   val PredefinedSubscription: String = "predefinedSubscription".toLowerCase(Locale.ROOT)
 

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarProvider.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarProvider.scala
@@ -167,7 +167,6 @@ private[pulsar] class PulsarProvider
       pollTimeoutMs(caseInsensitiveParams),
       failOnDataLoss(caseInsensitiveParams),
       subscriptionNamePrefix,
-      getPredefinedSubscription(parameters),
       jsonOptions)
   }
 

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarProvider.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarProvider.scala
@@ -167,6 +167,7 @@ private[pulsar] class PulsarProvider
       pollTimeoutMs(caseInsensitiveParams),
       failOnDataLoss(caseInsensitiveParams),
       subscriptionNamePrefix,
+      getPredefinedSubscription(parameters),
       jsonOptions)
   }
 
@@ -361,7 +362,7 @@ private[pulsar] object PulsarProvider extends Logging {
   private def getSubscriptionPrefix(
       parameters: Map[String, String],
       isBatch: Boolean = false): String = {
-    val defaultPrefix = if (isBatch) "spark-pulsar-batch" else "spar-pulsar"
+    val defaultPrefix = if (isBatch) "spark-pulsar-batch" else "spark-pulsar"
     parameters.getOrElse(SubscriptionPrefix, s"$defaultPrefix-${UUID.randomUUID}")
   }
 

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarRelation.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarRelation.scala
@@ -37,7 +37,6 @@ private[pulsar] class PulsarRelation(
     pollTimeoutMs: Int,
     failOnDataLoss: Boolean,
     subscriptionNamePrefix: String,
-    predefinedSubscription: Option[String],
     jsonOptions: JSONOptionsInRead)
     extends BaseRelation
     with TableScan

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarRelation.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarRelation.scala
@@ -37,6 +37,7 @@ private[pulsar] class PulsarRelation(
     pollTimeoutMs: Int,
     failOnDataLoss: Boolean,
     subscriptionNamePrefix: String,
+    predefinedSubscription: Option[String],
     jsonOptions: JSONOptionsInRead)
     extends BaseRelation
     with TableScan

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarSourceRDD.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarSourceRDD.scala
@@ -63,6 +63,7 @@ private[pulsar] abstract class PulsarSourceRDDBase(
     lazy val reader = CachedPulsarClient
       .getOrCreate(clientConf)
       .newReader(schema)
+      .subscriptionRolePrefix(subscriptionNamePrefix)
       .topic(topic)
       .startMessageId(startOffset)
       .startMessageIdInclusive()


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

Fixes #100 

### Motivation

*pulsar allows to configure subscriptionRolePrefix, but pulsar-spark does not configure the subscriptionRolePrefix parameter.*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

