### PR TITLE
[Improve] replace admin calls with client or consumer calls in PulsarHelper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
   <groupId>io.streamnative.connectors</groupId>
   <artifactId>pulsar-spark-connector_2.12</artifactId>
-  <version>3.2.0.2</version>
+  <version>3.2.0.1</version>
   <name>StreamNative :: Pulsar Spark Connector</name>
   <url>https://pulsar.apache.org</url>
   <inceptionYear>2019</inceptionYear>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
   <groupId>io.streamnative.connectors</groupId>
   <artifactId>pulsar-spark-connector_2.12</artifactId>
-  <version>3.2.0.1</version>
+  <version>3.2.0.2</version>
   <name>StreamNative :: Pulsar Spark Connector</name>
   <url>https://pulsar.apache.org</url>
   <inceptionYear>2019</inceptionYear>

--- a/src/main/scala/org/apache/spark/sql/pulsar/CachedConsumer.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/CachedConsumer.scala
@@ -1,0 +1,86 @@
+package org.apache.spark.sql.pulsar
+
+import java.util.concurrent.{ExecutionException, TimeUnit}
+import scala.util.control.NonFatal
+import com.google.common.cache._
+import com.google.common.util.concurrent.{ExecutionError, UncheckedExecutionException}
+import org.apache.pulsar.client.api.{Consumer, PulsarClient}
+import org.apache.pulsar.client.impl.schema.AutoConsumeSchema
+import org.apache.pulsar.client.api.schema.GenericRecord
+import org.apache.spark.SparkEnv
+import org.apache.spark.internal.Logging
+
+private[pulsar] object CachedConsumer extends Logging {
+
+  private val client: PulsarClient = PulsarClient.builder().serviceUrl("pulssar://localhost:6650").build()
+
+  private val defaultCacheExpireTimeout = TimeUnit.MINUTES.toMillis(10)
+
+  private lazy val cacheExpireTimeout: Long =
+    Option(SparkEnv.get)
+      .map(_.conf
+        .getTimeAsMs("spark.pulsar.client.cache.timeout", s"${defaultCacheExpireTimeout}ms"))
+      .getOrElse(defaultCacheExpireTimeout)
+
+  private val cacheLoader = new CacheLoader[(String, String), Consumer[GenericRecord]]() {
+    override def load(k: (String, String)): Consumer[GenericRecord] = {
+      val (topic, subscription) = (k._1, k._2)
+      try {
+        val consumer = client.newConsumer(new AutoConsumeSchema())
+          .topic(topic)
+          .subscriptionName(subscription)
+          .subscribe()
+
+        consumer
+      } catch {
+        case e: Throwable =>
+          logError(
+            s"Failed to create consumer to topic ${topic} with subscription ${subscription}"
+          )
+          throw e
+      }
+    }
+  }
+
+  private val removalListener = new RemovalListener[(String, String), Consumer[GenericRecord]]() {
+    override def onRemoval(notification: RemovalNotification[(String, String), Consumer[GenericRecord]]): Unit = {
+      val (topic, subscription) = (notification.getKey._1, notification.getKey._2)
+      val consumer = notification.getValue
+
+      try {
+        // TODO: check if need to call consumer.unscriber()
+        consumer.close()
+      } catch {
+        case NonFatal(e) => logWarning("Error while closing consumer.", e)
+      }
+    }
+  }
+
+  private lazy val guavaCache: LoadingCache[(String, String), Consumer[GenericRecord]] =
+    CacheBuilder
+      .newBuilder()
+      .expireAfterAccess(cacheExpireTimeout, TimeUnit.MILLISECONDS)
+      .removalListener(removalListener)
+      .build[(String, String), Consumer[GenericRecord]](cacheLoader)
+
+  private[pulsar] def getOrCreate(topic: String, subscription: String) : Consumer[GenericRecord] = {
+    try {
+      guavaCache.get((topic, subscription))
+    } catch {
+      case e @ (_: ExecutionException | _: UncheckedExecutionException | _: ExecutionError)
+        if e.getCause != null =>
+        throw e.getCause
+    }
+  }
+
+  private[pulsar] def close(topic: String, subscription: String): Unit = {
+    guavaCache.invalidate((topic, subscription))
+  }
+
+  private[pulsar] def clear(): Unit = {
+    logInfo("Cleaning up Consumer Cache.")
+    guavaCache.invalidateAll()
+  }
+
+}
+

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarHelper.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarHelper.scala
@@ -31,6 +31,8 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.pulsar.PulsarOptions._
 import org.apache.spark.sql.types.StructType
 
+import scala.util.control.NonFatal
+
 /**
  * A Helper class that is responsible for interacting with Pulsar to conduct subscription
  * management, cursor management, schema and topic metadata lookup etc.
@@ -295,7 +297,7 @@ private[pulsar] case class PulsarHelper(
           client.getPartitionedTopicMetadata(topic).get()
           waitList -= topic
         } catch {
-          case _: Throwable =>
+          case NonFatal(_) =>
             logInfo(s"The desired $topic doesn't existed, wait for 5 seconds.")
             Uninterruptibles.sleepUninterruptibly(5, TimeUnit.SECONDS)
         }

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarHelper.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarHelper.scala
@@ -17,9 +17,12 @@ import java.{util => ju}
 import java.io.Closeable
 import java.util.concurrent.TimeUnit
 import java.util.regex.Pattern
+
 import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.language.postfixOps
+import scala.util.control.NonFatal
+
 import org.apache.pulsar.client.admin.PulsarAdmin
 import org.apache.pulsar.client.api.{Message, MessageId}
 import org.apache.pulsar.client.impl.PulsarClientImpl
@@ -30,8 +33,6 @@ import org.apache.pulsar.shade.com.google.common.util.concurrent.Uninterruptible
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.pulsar.PulsarOptions._
 import org.apache.spark.sql.types.StructType
-
-import scala.util.control.NonFatal
 
 /**
  * A Helper class that is responsible for interacting with Pulsar to conduct subscription

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarHelper.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarHelper.scala
@@ -16,8 +16,8 @@ package org.apache.spark.sql.pulsar
 import java.{util => ju}
 import java.io.Closeable
 import java.util.concurrent.TimeUnit
-
 import java.util.regex.Pattern
+
 import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.language.postfixOps


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #<xyz>

*(or if this PR is one task of a github issue, please add `Master Issue: #<xyz>` to link to the master issue.)*

Master Issue: #113 

### Motivation

Reduce the hard dependency on PulsarAadmin as much as possible

### Modifications
Replace all admin calls with the equivalent client or consumer calls:

| admin call | client or consumer call |
| --- | ----------- |
| admin.topics().createSubscription(...) | consumer.subscribe() |
| admin.topics().resetCursor(...)  |  consumer.seek() |
| admin.topics().deleteSubscription(...)  |  consumer.unsubscribe() |
| admin.schemas().getSchemaInfo(...)  |  clientImpl.getSchema(...) |
| admin.topics().getLastMessageId(...)  |  consumer.getLastMessageId |
| admin.topics().getPartitionedTopicMetadata(...)  |  clientImpl.getPartitionedTopicMetadata(...) |
| admin.topics().getList(dest.getNamespace) | client.getLookup.getTopicsUnderNamespace(...) |


### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

With example applications using the connector, we can observe the following logs from spark driver:
```
-------------------------------------------
Batch: 4
-------------------------------------------
+--------------------+-----+--------------------+--------------------+--------------------+-----------+-------------------+
|               value|__key|             __topic|         __messageId|       __publishTime|__eventTime|__messageProperties|
+--------------------+-----+--------------------+--------------------+--------------------+-----------+-------------------+
|[48 65 6C 6C 6F 2...| null|persistent://publ...|[08 38 10 50 20 0...|2023-03-28 16:07:...|       null|                 {}|
|[48 65 6C 6C 6F 2...| null|persistent://publ...|[08 38 10 51 20 0...|2023-03-28 16:07:...|       null|                 {}|
|[48 65 6C 6C 6F 2...| null|persistent://publ...|[08 38 10 52 20 0...|2023-03-28 16:07:...|       null|                 {}|
|[48 65 6C 6C 6F 2...| null|persistent://publ...|[08 38 10 53 20 0...|2023-03-28 16:07:...|       null|                 {}|
|[48 65 6C 6C 6F 2...| null|persistent://publ...|[08 38 10 54 20 0...|2023-03-28 16:07:...|       null|                 {}|
|[48 65 6C 6C 6F 2...| null|persistent://publ...|[08 38 10 55 20 0...|2023-03-28 16:07:...|       null|                 {}|
|[48 65 6C 6C 6F 2...| null|persistent://publ...|[08 38 10 56 20 0...|2023-03-28 16:07:...|       null|                 {}|
|[48 65 6C 6C 6F 2...| null|persistent://publ...|[08 38 10 57 20 0...|2023-03-28 16:07:...|       null|                 {}|
|[48 65 6C 6C 6F 2...| null|persistent://publ...|[08 38 10 58 20 0...|2023-03-28 16:07:...|       null|                 {}|
|[48 65 6C 6C 6F 2...| null|persistent://publ...|[08 38 10 59 20 0...|2023-03-28 16:07:...|       null|                 {}|
+--------------------+-----+--------------------+--------------------+--------------------+-----------+-------------------+

23/03/28 16:07:30 INFO WriteToDataSourceV2Exec: Data source write support org.apache.spark.sql.execution.streaming.sources.MicroBatchWrite@5d7f2978 committed.
23/03/28 16:07:30 INFO CheckpointFileManager: Writing atomically to file:/tmp/bb486861-bd91-44d6-ae7f-c1a5bd7b9bd2/commits/4 using temp file file:/tmp/bb486861-bd91-44d6-ae7f-c1a5bd7b9bd2/commits/.4.2b8a1aa3-d710-42fd-96ac-349a2326e026.tmp
23/03/28 16:07:30 INFO CheckpointFileManager: Renamed temp file file:/tmp/bb486861-bd91-44d6-ae7f-c1a5bd7b9bd2/commits/.4.2b8a1aa3-d710-42fd-96ac-349a2326e026.tmp to file:/tmp/bb486861-bd91-44d6-ae7f-c1a5bd7b9bd2/commits/4
23/03/28 16:07:30 INFO MicroBatchExecution: Streaming query made progress: {
  "id" : "bfc00ad2-f3df-4b1f-b289-99c4faf596f6",
  "runId" : "77483b6b-627b-445c-96e2-b105d0f2f6ff",
  "name" : null,
  "timestamp" : "2023-03-28T23:07:30.004Z",
  "batchId" : 4,
  "numInputRows" : 10,
  "inputRowsPerSecond" : 0.3333222225925802,
  "processedRowsPerSecond" : 26.52519893899204,
  "durationMs" : {
    "addBatch" : 245,
    "getBatch" : 20,
    "getOffset" : 16,
    "queryPlanning" : 5,
    "triggerExecution" : 376,
    "walCommit" : 47
  },
  "stateOperators" : [ ],
  "sources" : [ {
    "description" : "org.apache.spark.sql.pulsar.PulsarSource@4aaeb58f",
    "startOffset" : {
      "persistent://public/default/spark-test2" : [ 8, 56, 16, 79, 48, 0 ]
    },
    "endOffset" : {
      "persistent://public/default/spark-test2" : [ 8, 56, 16, 89, 48, 0 ]
    },
    "latestOffset" : {
      "persistent://public/default/spark-test2" : [ 8, 56, 16, 89, 48, 0 ]
    },
    "numInputRows" : 10,
    "inputRowsPerSecond" : 0.3333222225925802,
    "processedRowsPerSecond" : 26.52519893899204
  } ],
  "sink" : {
    "description" : "org.apache.spark.sql.execution.streaming.ConsoleTable$@606bc1b6",
    "numOutputRows" : 10
  }
}
```

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [X] `no-need-doc` 
  
  Internal implementation details
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

