### PR TITLE
simplify sink schema check

### DIFF
--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarSource.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarSource.scala
@@ -19,7 +19,6 @@ import org.apache.pulsar.client.api.MessageId
 import org.apache.pulsar.client.impl.MessageIdImpl
 import org.apache.pulsar.common.schema.SchemaInfo
 
-import org.apache.spark.SparkEnv
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{DataFrame, SQLContext}
 import org.apache.spark.sql.catalyst.InternalRow
@@ -28,16 +27,16 @@ import org.apache.spark.sql.execution.streaming.{Offset, Source}
 import org.apache.spark.sql.types.StructType
 
 private[pulsar] class PulsarSource(
-                                    sqlContext: SQLContext,
-                                    pulsarHelper: PulsarHelper,
-                                    clientConf: ju.Map[String, Object],
-                                    readerConf: ju.Map[String, Object],
-                                    metadataPath: String,
-                                    startingOffsets: PerTopicOffset,
-                                    pollTimeoutMs: Int,
-                                    failOnDataLoss: Boolean,
-                                    subscriptionNamePrefix: String,
-                                    jsonOptions: JSONOptionsInRead)
+    sqlContext: SQLContext,
+    pulsarHelper: PulsarHelper,
+    clientConf: ju.Map[String, Object],
+    readerConf: ju.Map[String, Object],
+    metadataPath: String,
+    startingOffsets: PerTopicOffset,
+    pollTimeoutMs: Int,
+    failOnDataLoss: Boolean,
+    subscriptionNamePrefix: String,
+    jsonOptions: JSONOptionsInRead)
     extends Source
     with Logging {
 
@@ -55,7 +54,7 @@ private[pulsar] class PulsarSource(
 
   private var currentTopicOffsets: Option[Map[String, MessageId]] = None
 
-  private lazy val pulsarSchema: SchemaInfo = pulsarHelper.getPulsarSchema()
+  private lazy val pulsarSchema: SchemaInfo = pulsarHelper.getPulsarSchema
 
   override def schema(): StructType = SchemaUtils.pulsarSourceSchema(pulsarSchema)
 
@@ -152,13 +151,6 @@ private[pulsar] class PulsarSource(
     logInfo(
       "GetBatch generating RDD of offset range: " +
         offsetRanges.sortBy(_.topic).mkString(", "))
-
-    // Register the monitor metrics here.
-    val env = SparkEnv.get
-    if (env != null) {
-      val metrics = pulsarHelper.getMetrics()
-      env.metricsSystem.registerSource(metrics)
-    }
 
     sqlContext.internalCreateDataFrame(rdd.setName("pulsar"), schema(), isStreaming = true)
   }

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarWriteTask.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarWriteTask.scala
@@ -18,9 +18,7 @@ import java.util.function.BiConsumer
 
 import scala.collection.mutable
 
-import org.apache.pulsar.client.admin.PulsarAdmin
 import org.apache.pulsar.client.api.{MessageId, Producer}
-
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Cast, Literal, UnsafeProjection}
 import org.apache.spark.sql.types._
@@ -137,7 +135,6 @@ private[pulsar] abstract class PulsarRowWriter(
   // reuse producer through the executor
   protected lazy val singleProducer =
     if (topic.isDefined) {
-      SchemaUtils.uploadPulsarSchema(admin, topic.get, pulsarSchema.getSchemaInfo)
       PulsarSinks.createProducer(clientConf, producerConf, topic.get, pulsarSchema)
     } else null
   protected val topic2Producer: mutable.Map[String, Producer[_]] = mutable.Map.empty
@@ -150,7 +147,6 @@ private[pulsar] abstract class PulsarRowWriter(
     if (topic2Producer.contains(tp)) {
       topic2Producer(tp).asInstanceOf[Producer[T]]
     } else {
-      SchemaUtils.uploadPulsarSchema(admin, tp, pulsarSchema.getSchemaInfo)
       val p =
         PulsarSinks.createProducer(clientConf, producerConf, tp, pulsarSchema)
       topic2Producer.put(tp, p)


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #114

*(or if this PR is one task of a github issue, please add `Master Issue: #<xyz>` to link to the master issue.)*

Master Issue: #113 

### Motivation

The sink will do schema uploading and compatibility check, which can be achieved with the pulsar producer.
When creating the producer, if the topic doesn't exist or topic doesn't have schema, then the schema passed will be uploaded.
If the topic has an existing schema, and it's not compatible with the one used in spark application, an `PulsarClientException.IncompatibileSchema` exception will be thrown.

### Modifications

1. remove schema uploading via admin
2. stop checking schema compatibility

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [X] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

