### PR TITLE
clean initial offset setup

### DIFF
--- a/src/main/scala/org/apache/spark/sql/pulsar/CachedConsumer.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/CachedConsumer.scala
@@ -14,14 +14,11 @@
 package org.apache.spark.sql.pulsar
 
 import java.util.concurrent.TimeUnit
-
 import scala.util.{Failure, Success, Try}
-
 import com.google.common.cache._
-import org.apache.pulsar.client.api.{Consumer, PulsarClient}
+import org.apache.pulsar.client.api.{Consumer, PulsarClient, SubscriptionInitialPosition}
 import org.apache.pulsar.client.api.schema.GenericRecord
 import org.apache.pulsar.client.impl.schema.AutoConsumeSchema
-
 import org.apache.spark.SparkEnv
 import org.apache.spark.internal.Logging
 
@@ -50,6 +47,7 @@ private[pulsar] object CachedConsumer extends Logging {
           .newConsumer(new AutoConsumeSchema())
           .topic(topic)
           .subscriptionName(subscription)
+          .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
           .subscribe()) match {
         case Success(consumer) => consumer
         case Failure(exception) =>


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #107 

*(or if this PR is one task of a github issue, please add `Master Issue: #<xyz>` to link to the master issue.)*

Master Issue: #<xyz>

### Motivation

Currently, the connector will create readers with already-used subscription names to set up starting offsets. This causes conflicts and even requires additional permission or subscription work.

### Modifications

1. use the `CachedConsumer` instead of ad-hoc reader to establish initial offsets

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  internal changes
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

