### PR TITLE
[imporve] fix scalastyle issues

### DIFF
--- a/src/main/scala/org/apache/spark/sql/pulsar/CachedConsumer.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/CachedConsumer.scala
@@ -14,11 +14,14 @@
 package org.apache.spark.sql.pulsar
 
 import java.util.concurrent.TimeUnit
+
 import scala.util.{Failure, Success, Try}
+
 import com.google.common.cache._
 import org.apache.pulsar.client.api.{Consumer, PulsarClient, SubscriptionInitialPosition}
 import org.apache.pulsar.client.api.schema.GenericRecord
 import org.apache.pulsar.client.impl.schema.AutoConsumeSchema
+
 import org.apache.spark.SparkEnv
 import org.apache.spark.internal.Logging
 

--- a/src/main/scala/org/apache/spark/sql/pulsar/CachedPulsarClient.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/CachedPulsarClient.scala
@@ -23,6 +23,7 @@ import com.google.common.cache._
 import com.google.common.util.concurrent.{ExecutionError, UncheckedExecutionException}
 import org.apache.pulsar.client.api.PulsarClient
 import org.apache.pulsar.client.impl.PulsarClientImpl
+
 import org.apache.spark.SparkEnv
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.pulsar.PulsarOptions._

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarHelper.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarHelper.scala
@@ -30,6 +30,7 @@ import org.apache.pulsar.common.api.proto.CommandGetTopicsOfNamespace
 import org.apache.pulsar.common.naming.TopicName
 import org.apache.pulsar.common.schema.SchemaInfo
 import org.apache.pulsar.shade.com.google.common.util.concurrent.Uninterruptibles
+
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.pulsar.PulsarOptions._
 import org.apache.spark.sql.types.StructType

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarSinks.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarSinks.scala
@@ -19,8 +19,9 @@ import java.util.concurrent.TimeUnit
 import scala.util.control.NonFatal
 
 import org.apache.pulsar.client.api.{Producer, PulsarClientException, Schema}
+
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.{AnalysisException, DataFrame, SQLContext, SparkSession}
+import org.apache.spark.sql.{AnalysisException, DataFrame, SparkSession, SQLContext}
 import org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Literal}
 import org.apache.spark.sql.execution.QueryExecution

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarSourceRDD.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarSourceRDD.scala
@@ -99,8 +99,8 @@ private[pulsar] abstract class PulsarSourceRDDBase(
               case (_: BatchMessageIdImpl, _: BatchMessageIdImpl) =>
               // we seek using a batch message id, we can read next directly in `getNext()`
               case (_: MessageIdImpl, cbmid: BatchMessageIdImpl) =>
-                // we seek using a message id, this is supposed to be read by previous task since it's
-                // inclusive for the last batch (start, end], so we skip this batch
+                // we seek using a message id, this is supposed to be read by previous task since
+                // it's inclusive for the last batch (start, end], so we skip this batch
                 val newStart = new MessageIdImpl(
                   cbmid.getLedgerId,
                   cbmid.getEntryId + 1,

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarWriteTask.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarWriteTask.scala
@@ -19,6 +19,7 @@ import java.util.function.BiConsumer
 import scala.collection.mutable
 
 import org.apache.pulsar.client.api.{MessageId, Producer}
+
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Cast, Literal, UnsafeProjection}
 import org.apache.spark.sql.types._


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #<xyz>

*(or if this PR is one task of a github issue, please add `Master Issue: #<xyz>` to link to the master issue.)*

Master Issue: #<xyz>

### Motivation

`mvn verify` reported the following scala style issue:

```
error file=/home/runner/work/pulsar-spark/pulsar-spark/src/main/scala/org/apache/spark/sql/pulsar/CachedConsumer.scala message=There should at least one a single empty line separating groups java and scala. line=17 column=0
error file=/home/runner/work/pulsar-spark/pulsar-spark/src/main/scala/org/apache/spark/sql/pulsar/CachedConsumer.scala message=There should at least one a single empty line separating groups scala and 3rdParty. line=18 column=0
error file=/home/runner/work/pulsar-spark/pulsar-spark/src/main/scala/org/apache/spark/sql/pulsar/CachedConsumer.scala message=There should at least one a single empty line separating groups 3rdParty and spark. line=22 column=0
error file=/home/runner/work/pulsar-spark/pulsar-spark/src/main/scala/org/apache/spark/sql/pulsar/CachedPulsarClient.scala message=There should at least one a single empty line separating groups 3rdParty and spark. line=26 column=0
error file=/home/runner/work/pulsar-spark/pulsar-spark/src/main/scala/org/apache/spark/sql/pulsar/PulsarHelper.scala message=There should at least one a single empty line separating groups 3rdParty and spark. line=33 column=0
error file=/home/runner/work/pulsar-spark/pulsar-spark/src/main/scala/org/apache/spark/sql/pulsar/PulsarSinks.scala message=There should at least one a single empty line separating groups 3rdParty and spark. line=22 column=0
error file=/home/runner/work/pulsar-spark/pulsar-spark/src/main/scala/org/apache/spark/sql/pulsar/PulsarSinks.scala message=SparkSession should come before SQLContext. line=23 column=28
error file=/home/runner/work/pulsar-spark/pulsar-spark/src/main/scala/org/apache/spark/sql/pulsar/PulsarSourceRDD.scala message=File line length exceeds 100 characters line=102
```

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [X] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

