### PR TITLE
Added message properties serialization to Pulsar write task.

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ df.selectExpr("CAST(__key AS STRING)", "CAST(value AS STRING)")
 
 ### Write data to Pulsar
 
-The DataFrame written to Pulsar can have arbitrary schema, since each record in DataFrame is transformed as one message sent to Pulsar, fields of DataFrame are divided into two groups: `__key` and `__eventTime` fields are encoded as metadata of Pulsar message; other fields are grouped and encoded using AVRO and put in `value()`:
+The DataFrame written to Pulsar can have arbitrary schema, since each record in DataFrame is transformed as one message sent to Pulsar, fields of DataFrame are divided into two groups: `__key`, `__eventTime` and `__messageProperties` fields are encoded as metadata of Pulsar message; other fields are grouped and encoded using AVRO and put in `value()`:
 ```scala
 producer.newMessage().key(__key).value(avro_encoded_fields).eventTime(__eventTime)
 ```


### PR DESCRIPTION
### Motivation

I wanted to have the ability to add message properties when writing messages to Pulsar.

### Modifications

I have changed the createProjections and sendRow methods in order to correctly serialize the message properties.
Since there are currently no proper tests, it might be worth for someone to take another look at creating them.
In addition, I have mentioned the __messageProperties support in the README.md

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:

- [ ] This change added tests and can be verified as follows:

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required`
- [ ] `no-need-doc`
- [x] `doc`
