### PR TITLE
Bump to Spark 3.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,10 +67,10 @@
     <!-- dependencies -->
     <!-- latest version from apache pulsar -->
     <pulsar.version>2.10.2</pulsar.version>
-    <scala.version>2.12.10</scala.version>
+    <scala.version>2.12.17</scala.version>
     <scala.binary.version>2.12</scala.binary.version>
     <scalatest.version>3.2.14</scalatest.version>
-    <spark.version>3.2.2</spark.version>
+    <spark.version>3.4.0</spark.version>
     <commons-io.version>2.11.0</commons-io.version>
     <testcontainers.version>1.17.6</testcontainers.version>
 

--- a/src/main/scala/org/apache/spark/sql/pulsar/JSONParser.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/JSONParser.scala
@@ -161,7 +161,7 @@ class JacksonRecordParser(schema: DataType, val options: JSONOptions) extends Lo
             // See https://issues.apache.org/jira/browse/SPARK-10681.
             Long.box {
               Try(
-                TimestampFormatter(options.timestampFormat, options.zoneId, true)
+                TimestampFormatter(options.timestampFormatInWrite, options.zoneId, true)
                   .parse(stringValue))
                 .getOrElse {
                   // If it fails to parse, then tries the way used in 2.0 and 1.x for backwards
@@ -184,7 +184,7 @@ class JacksonRecordParser(schema: DataType, val options: JSONOptions) extends Lo
           // See https://issues.apache.org/jira/browse/SPARK-10681.x
           Long.box {
             Try(
-              TimestampFormatter(options.timestampFormat, options.zoneId, true).parse(
+              TimestampFormatter(options.timestampFormatInWrite, options.zoneId, true).parse(
                 stringValue))
               .orElse {
                 // If it fails to parse, then tries the way used in 2.0 and 1.x for backwards


### PR DESCRIPTION
### Motivation

We would like to use pulsar-spark with Spark 3.4.0

### Modifications

Updated pom.xml to Apache Spark 3.4.0 and adjusted TimestampFormatter parameters

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:

- [ ] This change added tests and can be verified as follows:

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required`
- [x] `no-need-doc`
- [ ] `doc`
