### PR TITLE
close producer during cleanup

### DIFF
--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarWriteTask.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarWriteTask.scala
@@ -15,11 +15,8 @@ package org.apache.spark.sql.pulsar
 
 import java.{util => ju}
 import java.util.function.BiConsumer
-
 import scala.collection.mutable
-
 import org.apache.pulsar.client.api.{MessageId, Producer}
-
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Cast, Literal, UnsafeProjection}
 import org.apache.spark.sql.types._
@@ -209,6 +206,11 @@ private[pulsar] abstract class PulsarRowWriter(
 
   protected def producerClose(): Unit = {
     producerFlush()
+    if (singleProducer != null) {
+      singleProducer.close()
+    } else {
+      topic2Producer.foreach(_._2.close())
+    }
     topic2Producer.clear()
   }
 }

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarWriteTask.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarWriteTask.scala
@@ -19,6 +19,7 @@ import java.util.function.BiConsumer
 import scala.collection.mutable
 
 import org.apache.pulsar.client.api.{MessageId, Producer}
+
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Cast, Literal, UnsafeProjection}
 import org.apache.spark.sql.types._

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarWriteTask.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarWriteTask.scala
@@ -15,7 +15,9 @@ package org.apache.spark.sql.pulsar
 
 import java.{util => ju}
 import java.util.function.BiConsumer
+
 import scala.collection.mutable
+
 import org.apache.pulsar.client.api.{MessageId, Producer}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Cast, Literal, UnsafeProjection}


### PR DESCRIPTION
### Motivation

fix #136 

Currently, producers will stay connected with a broker after each micro-batch, thus causing a broker-side producer spam issue and eventually affecting the broker's performance.

### Modifications

call `producer.close()` when clean up

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:

- [ ] This change added tests and can be verified as follows:

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required`
- [x] `no-need-doc`
- [ ] `doc`
