### PR TITLE
Fix the null pointer exception when there is no active session in the current thread.

### DIFF
--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarProvider.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarProvider.scala
@@ -517,7 +517,7 @@ private[pulsar] object PulsarProvider extends Logging {
   }
 
   private def jsonOptions: JSONOptionsInRead = {
-    val spark = SparkSession.getActiveSession.get
+    val spark = SparkSession.builder().getOrCreate()
     new JSONOptionsInRead(
       CaseInsensitiveMap(Map.empty),
       spark.sessionState.conf.sessionLocalTimeZone,


### PR DESCRIPTION
### Motivation

https://github.com/streamnative/pulsar-spark/issues/37 reported that null pointer exception may be thrown from jsonOptions if there is no active spark session.

### Modifications
Call SparkSession.builder().getOrCreate(). It will look up the thread local spark session, then global session, and create a new session if neither exists.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

- [x] This change is a trivial rework / code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:

- [ ] This change added tests and can be verified as follows:

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required`
- [x] `no-need-doc`
- [ ] `doc`
