### PR TITLE
stop shading pulsar client and commons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -402,18 +402,6 @@
                   <shadedPattern>org.apache.pulsar.shade.org.apache.commons</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>org.apache.pulsar.client</pattern>
-                  <shadedPattern>org.apache.pulsar.shade.org.apache.pulsar.client</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.apache.pulsar.common</pattern>
-                  <shadedPattern>org.apache.pulsar.shade.org.apache.pulsar.common</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.bouncycastle</pattern>
-                  <shadedPattern>org.apache.pulsar.shade.org.bouncycastle</shadedPattern>
-                </relocation>
-                <relocation>
                   <pattern>org.lz4</pattern>
                   <shadedPattern>org.apache.pulsar.shade.org.lz4</shadedPattern>
                 </relocation>


### PR DESCRIPTION
### Motivation
1.  the authentication plugin config is full class name, that means we cannot shade these classes.
2. Per: https://jlbp.dev/JLBP-18. We should not shade dependencies proactively.

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:

- [ ] This change added tests and can be verified as follows:

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required`
- [x] `no-need-doc`
- [ ] `doc`
