### PR TITLE
Fix the issue of getting initial offset with user provided start

### DIFF
--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarHelper.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarHelper.scala
@@ -441,25 +441,25 @@ private[pulsar] case class PulsarHelper(
       topic: String,
       time: Option[Long],
       offset: Option[MessageId]): MessageIdImpl = {
-    val (subscriptionName, _) = extractSubscription(predefinedSubscription, topic)
-    val consumer =
-      CachedConsumer.getOrCreate(topic, subscriptionName, client.asInstanceOf[PulsarClient])
-
     // seek to specified offset or time and get the actual corresponding message id
     // we don't call consumer.acknowledge() here because the message is not processed yet
     if (time.isDefined || offset.isDefined) {
-      // Call getLastMessageId to reconnect the consumer before seeking.
-      if (!consumer.isConnected) consumer.getLastMessageId
+      val reader = client
+        .newReader()
+        .subscriptionRolePrefix(driverGroupIdPrefix)
+        .topic(topic)
+        .startMessageId(offset.getOrElse(MessageId.earliest))
+        .startMessageIdInclusive()
+        .create()
       (time, offset) match {
-        case (None, Some(o)) => consumer.seek(o)
-        case (Some(t), None) => consumer.seek(t)
+        case (None, Some(o)) =>
+        case (Some(t), None) => reader.seek(t)
         case _ =>
           throw new IllegalArgumentException(
             s"one of time and offset should be set. time: $time, offset: $offset")
       }
-      val message = consumer.receive()
-      // This must be wrapped in UserProvidedMessageId to prevent first message from being skipped
-      // because start offset is exclusive by default.
+      val message = reader.readNext()
+      reader.close()
       if (message != null) UserProvidedMessageId(PulsarSourceUtils.mid2Impl(message.getMessageId))
       else UserProvidedMessageId(MessageId.earliest)
     } else {

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarHelper.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarHelper.scala
@@ -449,7 +449,7 @@ private[pulsar] case class PulsarHelper(
     // seek to specified offset or time and get the actual corresponding message id
     // we don't call consumer.acknowledge() here because the message is not processed yet
     if (time.isDefined || offset.isDefined) {
-      // Call getLastMessageId to reconnect to consumer before seeking.
+      // Call getLastMessageId to reconnect the consumer before seeking.
       if (!consumer.isConnected) consumer.getLastMessageId
       (time, offset) match {
         case (None, Some(o)) => consumer.seek(o)

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarHelper.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarHelper.scala
@@ -23,8 +23,7 @@ import scala.language.postfixOps
 import scala.util.control.NonFatal
 
 import org.apache.pulsar.client.api.{MessageId, PulsarClient}
-import org.apache.pulsar.client.api.schema.GenericRecord
-import org.apache.pulsar.client.impl.{ConsumerImpl, MessageIdImpl, PulsarClientImpl}
+import org.apache.pulsar.client.impl.{MessageIdImpl, PulsarClientImpl}
 import org.apache.pulsar.client.impl.schema.BytesSchema
 import org.apache.pulsar.common.api.proto.CommandGetTopicsOfNamespace
 import org.apache.pulsar.common.naming.TopicName

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarHelper.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarHelper.scala
@@ -449,6 +449,7 @@ private[pulsar] case class PulsarHelper(
     // seek to specified offset or time and get the actual corresponding message id
     // we don't call consumer.acknowledge() here because the message is not processed yet
     if (time.isDefined || offset.isDefined) {
+      // Call getLastMessageId to reconnect to consumer before seeking.
       if (!consumer.isConnected) consumer.getLastMessageId
       (time, offset) match {
         case (None, Some(o)) => consumer.seek(o)


### PR DESCRIPTION
### Motivation

Fix the 2 bugs in getUserProvidedMessageId
1. consumer.asInstanceOf[ConsumerImpl[GenericRecord]].hasMessageAvailable may throw exception if consumer is freshly started.
2. initial message id is not wrap in UserProvidedMessageId class, which cause the first message to be skipped.
3. when consumer seek() and read() it actually skip the start message if the message is not a batch message

### Modifications
No longer call hasMessageAvailable() method.
Wrap initial offset inside UserProvidedMessageId
change to use reader instead of consumer.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:

- [ ] This change added tests and can be verified as follows:

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required`
- [x] `no-need-doc`
- [ ] `doc`
