### PR TITLE
improve logging

### DIFF
--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarSource.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarSource.scala
@@ -63,7 +63,7 @@ private[pulsar] class PulsarSource(
     initialTopicOffsets
     val latest = pulsarHelper.fetchLatestOffsets()
     currentTopicOffsets = Some(latest.topicOffsets)
-    logDebug(s"GetOffset: ${latest.topicOffsets.toSeq.map(_.toString).sorted}")
+    logInfo(s"GetOffset: ${latest.topicOffsets.toSeq.map(_.toString).sorted}")
     Some(latest.asInstanceOf[Offset])
   }
 

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarSource.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarSource.scala
@@ -63,7 +63,7 @@ private[pulsar] class PulsarSource(
     initialTopicOffsets
     val latest = pulsarHelper.fetchLatestOffsets()
     currentTopicOffsets = Some(latest.topicOffsets)
-    logInfo(s"GetOffset: ${latest.topicOffsets.toSeq.map(_.toString).sorted}")
+    logDebug(s"GetOffset: ${latest.topicOffsets.toSeq.map(_.toString).sorted}")
     Some(latest.asInstanceOf[Offset])
   }
 

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarSources.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarSources.scala
@@ -172,7 +172,7 @@ class PulsarSourceInitialOffsetWriter(sparkSession: SparkSession, metadataPath: 
   }
 }
 
-private[pulsar] class PulsarOffsetRange private (
+private[pulsar] case class PulsarOffsetRange private (
     private var topic_ : String,
     private var fromOffset_ : MessageId,
     private var untilOffset_ : MessageId,


### PR DESCRIPTION
### Motivation
GetBatch doesn't print offset range correctly because it is not a case class
`2023-08-11T22:57:20.8908016Z stream execution thread for [id = 71ece58b-2fbe-4937-b4ef-d6bfa68aa396, runId = b6efacc4-df39-45b4-958c-e63e13698840]: GetBatch generating RDD of offset range: org.apache.spark.sql.pulsar.PulsarOffsetRange@53a7eb97`

### Modifications
Make offset range a case class so that it can be printed correctly.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

- [x] This change is a trivial rework / code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:

- [ ] This change added tests and can be verified as follows:

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required`
- [x] `no-need-doc`
- [ ] `doc`
