### PR TITLE
Fix data duplicate and data loss

### DIFF
--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarSourceRDD.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarSourceRDD.scala
@@ -80,7 +80,7 @@ private[pulsar] abstract class PulsarSourceRDDBase(
       try {
         if (!startOffset
             .isInstanceOf[UserProvidedMessageId] && startOffset != MessageId.earliest) {
-          reader.seek(startOffset)
+          // Read and skip the first message when the start offset is exclusive.
           currentMessage = reader.readNext(pollTimeoutMs, TimeUnit.MILLISECONDS)
           if (currentMessage == null) {
             isLast = true
@@ -110,6 +110,8 @@ private[pulsar] abstract class PulsarSourceRDDBase(
               // current entry is a non-batch entry, we can read next directly in `getNext()`
             }
           }
+          // If start offset is exclusive and equal to end offset, don't read any data.
+          if (currentId != null && enterEndFunc(currentId)) isLast = true
         }
       } catch {
         case e: PulsarClientException =>


### PR DESCRIPTION
### Motivation
When start offset is exclusive and equal to end offset, current code will read past the end, which results in data duplicate.
Reader seek() is redundant inside pulsar RDD(because start offset is already specified for the reader) and sometimes cause data loss(sometimes the cursor forward when seeking the current offset).

### Modifications
Remove redundant reader seek()
Set isLast flag to true if start offset = end offset when start offset is exclusive.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:

- [ ] This change added tests and can be verified as follows:

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required`
- [x] `no-need-doc`
- [ ] `doc`
