### PR TITLE
Fix the build failure caused by spark upgrade

### DIFF
--- a/src/test/scala/org/apache/spark/sql/pulsar/PulsarMicroBatchSourceSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/pulsar/PulsarMicroBatchSourceSuite.scala
@@ -25,11 +25,6 @@ import org.apache.spark.sql.streaming.Trigger.ProcessingTime
 import org.apache.spark.util.Utils
 
 class PulsarMicroBatchV1SourceSuite extends PulsarMicroBatchSourceSuiteBase {
-
-  override def beforeAll(): Unit = {
-    super.beforeAll()
-  }
-
   test("V1 Source is used by default") {
     val topic = newTopic()
 
@@ -43,7 +38,7 @@ class PulsarMicroBatchV1SourceSuite extends PulsarMicroBatchSourceSuiteBase {
       makeSureGetOffsetCalled,
       AssertOnQuery { query =>
         query.logicalPlan.collect {
-          case StreamingExecutionRelation(_: PulsarSource, _) => true
+          case StreamingExecutionRelation(_: PulsarSource, _, _) => true
         }.nonEmpty
       }
     )

--- a/src/test/scala/org/apache/spark/sql/pulsar/PulsarSinkSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/pulsar/PulsarSinkSuite.scala
@@ -13,9 +13,10 @@
  */
 package org.apache.spark.sql.pulsar
 
+import java.sql.Date
 import java.text.SimpleDateFormat
 import java.util.concurrent.atomic.AtomicInteger
-import java.util.{Date, Locale}
+import java.util.Locale
 import scala.reflect.ClassTag
 import org.scalatest.time.SpanSugar._
 import org.apache.pulsar.client.api.Schema
@@ -113,7 +114,7 @@ class PulsarSinkSuite extends StreamTest with PulsarTest with SharedSparkSession
     batchCheck[Date](
       Schema.DATE.getSchemaInfo,
       dateSeq,
-      Encoders.bean(classOf[Date]),
+      Encoders.DATE,
       dateFormat.format(_))
   }
 
@@ -367,9 +368,9 @@ class PulsarSinkSuite extends StreamTest with PulsarTest with SharedSparkSession
 
   test("streaming - write date") {
     val dateFormat = new SimpleDateFormat("yyyy-MM-dd")
-    streamCheck[java.sql.Date](
+    streamCheck[Date](
       Schema.DATE.getSchemaInfo,
-      dateSeq.map(d => new java.sql.Date(d.getTime)),
+      dateSeq,
       Encoders.DATE,
       dateFormat.format(_))
   }

--- a/src/test/scala/org/apache/spark/sql/pulsar/PulsarSourceSuiteBase.scala
+++ b/src/test/scala/org/apache/spark/sql/pulsar/PulsarSourceSuiteBase.scala
@@ -14,12 +14,11 @@
 package org.apache.spark.sql.pulsar
 
 import java.nio.charset.StandardCharsets.UTF_8
+import java.sql.Date
 import java.text.SimpleDateFormat
-import java.util.{Date, Locale}
+import java.util.Locale
 import scala.reflect.ClassTag
-import org.apache.pulsar.client.api.schema.GenericRecord
 import org.apache.pulsar.client.api.{MessageId, Schema}
-import org.apache.pulsar.client.impl.ConsumerImpl
 import org.apache.pulsar.common.schema.SchemaInfo
 import org.apache.spark.sql.execution.streaming.StreamExecution
 import org.apache.spark.sql.pulsar.PulsarProvider.getPulsarOffset
@@ -306,7 +305,7 @@ abstract class PulsarSourceSuiteBase extends PulsarSourceTest {
     check[Date](
       Schema.DATE.getSchemaInfo,
       dateSeq,
-      Encoders.bean(classOf[Date]),
+      Encoders.DATE,
       dateFormat.format(_))
   }
 

--- a/src/test/scala/org/apache/spark/sql/pulsar/PulsarSourceTest.scala
+++ b/src/test/scala/org/apache/spark/sql/pulsar/PulsarSourceTest.scala
@@ -100,8 +100,8 @@ class PulsarSourceTest extends StreamTest with SharedSparkSession with PulsarTes
         "Cannot add data when there is no query for finding the active pulsar source")
 
       val sources = query.get.logicalPlan.collect {
-          case StreamingExecutionRelation(source: PulsarSource, _) => source
-          case StreamingExecutionRelation(source: PulsarMicroBatchReader, _) => source
+          case StreamingExecutionRelation(source: PulsarSource, _, _) => source
+          case StreamingExecutionRelation(source: PulsarMicroBatchReader, _, _) => source
         }.distinct
 
       if (sources.isEmpty) {
@@ -159,8 +159,8 @@ class PulsarSourceTest extends StreamTest with SharedSparkSession with PulsarTes
         "Cannot add data when there is no query for finding the active pulsar source")
 
       val sources = query.get.logicalPlan.collect {
-          case StreamingExecutionRelation(source: PulsarSource, _) => source
-          case StreamingExecutionRelation(source: PulsarMicroBatchReader, _) => source
+          case StreamingExecutionRelation(source: PulsarSource, _, _) => source
+          case StreamingExecutionRelation(source: PulsarMicroBatchReader, _, _) => source
         }.distinct
 
       if (sources.isEmpty) {
@@ -191,7 +191,7 @@ class PulsarSourceTest extends StreamTest with SharedSparkSession with PulsarTes
 
   protected def newTopic(): String = TopicName.get(s"topic-${topicId.getAndIncrement()}").toString
 
-  override def testStream(_stream: Dataset[_], outputMode: OutputMode)(
+  override def testStream(_stream: Dataset[_], outputMode: OutputMode, extraOptions: Map[String,String])(
     actions: StreamAction*): Unit = synchronized {
     import org.apache.spark.sql.streaming.util.StreamManualClock
 

--- a/src/test/scala/org/apache/spark/sql/pulsar/SchemaData.scala
+++ b/src/test/scala/org/apache/spark/sql/pulsar/SchemaData.scala
@@ -29,7 +29,7 @@ object SchemaData {
   cal.clear()
   val dateSeq = (1 to 5).map { i =>
     cal.set(2019, 0, i)
-    cal.getTime
+    new java.sql.Date(cal.getTime.getTime)
   }
 
   cal.clear()


### PR DESCRIPTION
### Motivation

Test build fail after spark dependency upgrade to 3.4

### Modifications

Fix the build failure caused by spark upgrade

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:

- [ ] This change added tests and can be verified as follows:

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required`
- [x] `no-need-doc`
- [ ] `doc`
