### PR TITLE
Fix data loss of initial batch and add available now trigger test

### DIFF
--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarSources.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarSources.scala
@@ -162,13 +162,25 @@ class PulsarSourceInitialOffsetWriter(sparkSession: SparkSession, metadataPath: 
                         startingOffsets: PerTopicOffset,
                         poolTimeoutMs: Int,
                         reportDataLoss: String => Unit): SpecificPulsarOffset = {
-    get(0).getOrElse {
+    val deserializedOffset = get(0).map(markOffsetUserProvided(_))
+    deserializedOffset.getOrElse {
       val actualOffsets = SpecificPulsarOffset(
         pulsarHelper.actualOffsets(startingOffsets, poolTimeoutMs, reportDataLoss))
       add(0, actualOffsets)
       logInfo(s"Initial Offsets: $actualOffsets")
       actualOffsets
     }
+  }
+
+  // Mark a specific offset as user provided so that first records are not skipped.
+  // This is needed because when initial offsets are deserialized from the metadata log,
+  // they lose the UserProvidedMessageId type.
+  private def markOffsetUserProvided(offsets: SpecificPulsarOffset): SpecificPulsarOffset = {
+    val wrappedOffsets = offsets.topicOffsets.map { case (tp, mid) =>
+      if (mid.isInstanceOf[UserProvidedMessageId] || mid == MessageId.earliest || mid == MessageId.latest) (tp, mid)
+      else (tp, UserProvidedMessageId(mid))
+    }
+    SpecificPulsarOffset(wrappedOffsets)
   }
 }
 

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarSources.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarSources.scala
@@ -177,7 +177,10 @@ class PulsarSourceInitialOffsetWriter(sparkSession: SparkSession, metadataPath: 
   // they lose the UserProvidedMessageId type.
   private def markOffsetUserProvided(offsets: SpecificPulsarOffset): SpecificPulsarOffset = {
     val wrappedOffsets = offsets.topicOffsets.map { case (tp, mid) =>
-      if (mid.isInstanceOf[UserProvidedMessageId] || mid == MessageId.earliest || mid == MessageId.latest) (tp, mid)
+      if (mid.isInstanceOf[UserProvidedMessageId] || mid == MessageId.earliest ||
+        mid == MessageId.latest) {
+        (tp, mid)
+      }
       else (tp, UserProvidedMessageId(mid))
     }
     SpecificPulsarOffset(wrappedOffsets)

--- a/src/test/scala/org/apache/spark/sql/pulsar/PulsarMicroBatchSourceSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/pulsar/PulsarMicroBatchSourceSuite.scala
@@ -25,11 +25,6 @@ import org.apache.spark.sql.streaming.Trigger.ProcessingTime
 import org.apache.spark.util.Utils
 
 class PulsarMicroBatchV1SourceSuite extends PulsarMicroBatchSourceSuiteBase {
-
-  override def beforeAll(): Unit = {
-    super.beforeAll()
-  }
-
   test("V1 Source is used by default") {
     val topic = newTopic()
 
@@ -43,7 +38,7 @@ class PulsarMicroBatchV1SourceSuite extends PulsarMicroBatchSourceSuiteBase {
       makeSureGetOffsetCalled,
       AssertOnQuery { query =>
         query.logicalPlan.collect {
-          case StreamingExecutionRelation(_: PulsarSource, _) => true
+          case StreamingExecutionRelation(_: PulsarSource, _, _) => true
         }.nonEmpty
       }
     )

--- a/src/test/scala/org/apache/spark/sql/pulsar/PulsarMicroBatchSourceTriggerAvailableNowSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/pulsar/PulsarMicroBatchSourceTriggerAvailableNowSuite.scala
@@ -1,0 +1,247 @@
+package org.apache.spark.sql.pulsar
+
+import org.apache.spark.sql.pulsar.PulsarOptions.{FailOnDataLossOptionKey, ServiceUrlOptionKey, StartingOffsetsOptionKey, StartingTime, TopicMulti, TopicPattern, TopicSingle}
+import org.apache.spark.sql.streaming.Trigger
+
+class PulsarMicroBatchSourceTriggerAvailableNowSuite extends PulsarSourceTest {
+  import testImplicits._
+  override val defaultTrigger: Trigger =  Trigger.AvailableNow()
+  val failOnDataLoss = true
+
+  test(s"assign from latest offsets (failOnDataLoss: $failOnDataLoss)") {
+    val topic = newTopic()
+    testFromLatestOffsets(
+      topic,
+      addPartitions = false,
+      failOnDataLoss = failOnDataLoss,
+      TopicSingle -> topic)
+  }
+
+  test(s"assign from earliest offsets (failOnDataLoss: $failOnDataLoss)") {
+    val topic = newTopic()
+    testFromEarliestOffsets(
+      topic,
+      addPartitions = false,
+      failOnDataLoss = failOnDataLoss,
+      TopicSingle -> topic)
+  }
+
+  test(s"assign from time (failOnDataLoss: $failOnDataLoss)") {
+    val topic = newTopic()
+    testFromTime(
+      topic,
+      addPartitions = false,
+      failOnDataLoss = failOnDataLoss,
+      TopicSingle -> topic)
+  }
+
+  test(s"assign from specific offsets (failOnDataLoss: $failOnDataLoss)") {
+    val topic = newTopic()
+    testFromSpecificOffsets(
+      topic,
+      failOnDataLoss = failOnDataLoss,
+      TopicSingle -> topic,
+      FailOnDataLossOptionKey -> failOnDataLoss.toString)
+  }
+
+  test(s"subscribing topic by name from latest offsets (failOnDataLoss: $failOnDataLoss)") {
+    val topic = newTopic()
+    testFromLatestOffsets(
+      topic,
+      addPartitions = true,
+      failOnDataLoss = failOnDataLoss,
+      TopicMulti -> topic)
+  }
+
+  test(s"subscribing topic by name from earliest offsets (failOnDataLoss: $failOnDataLoss)") {
+    val topic = newTopic()
+    testFromEarliestOffsets(
+      topic,
+      addPartitions = true,
+      failOnDataLoss = failOnDataLoss,
+      TopicMulti -> topic)
+  }
+
+  test(s"subscribing topic by name from specific offsets (failOnDataLoss: $failOnDataLoss)") {
+    val topic = newTopic()
+    testFromSpecificOffsets(topic, failOnDataLoss = failOnDataLoss, TopicMulti -> topic)
+  }
+
+  test(s"subscribing topic by pattern from latest offsets (failOnDataLoss: $failOnDataLoss)") {
+    val topicPrefix = newTopic()
+    val topic = topicPrefix + "-suffix"
+    testFromLatestOffsets(
+      topic,
+      addPartitions = true,
+      failOnDataLoss = failOnDataLoss,
+      TopicPattern -> s"$topicPrefix-.*")
+  }
+
+  test(s"subscribing topic by pattern from earliest offsets (failOnDataLoss: $failOnDataLoss)") {
+    val topicPrefix = newTopic()
+    val topic = topicPrefix + "-suffix"
+    testFromEarliestOffsets(
+      topic,
+      addPartitions = true,
+      failOnDataLoss = failOnDataLoss,
+      TopicPattern -> s"$topicPrefix-.*")
+  }
+
+  test(s"subscribing topic by pattern from specific offsets (failOnDataLoss: $failOnDataLoss)") {
+    val topicPrefix = newTopic()
+    val topic = topicPrefix + "-suffix"
+    testFromSpecificOffsets(
+      topic,
+      failOnDataLoss = failOnDataLoss,
+      TopicPattern -> s"$topicPrefix-.*")
+  }
+
+  private def testFromLatestOffsets(
+    topic: String,
+    addPartitions: Boolean,
+    failOnDataLoss: Boolean,
+    options: (String, String)*): Unit = {
+
+    sendMessages(topic, Array("-1", "0", "1"))
+    require(getLatestOffsets(Set(topic)).size === 1)
+
+    val reader = spark.readStream
+      .format("pulsar")
+      .option(StartingOffsetsOptionKey, "latest")
+      .option(ServiceUrlOptionKey, serviceUrl)
+      .option(FailOnDataLossOptionKey, failOnDataLoss.toString)
+
+    options.foreach { case (k, v) => reader.option(k, v) }
+    val pulsar = reader
+      .load()
+      .selectExpr("CAST(__key AS STRING)", "CAST(value AS STRING)")
+      .as[(String, String)]
+    val mapped = pulsar.map(kv => kv._2.toInt + 1)
+
+    testStream(mapped)(
+      StopStream,
+      AddPulsarData(Set(topic), 2, 3),
+      StartStream(),
+      CheckAnswer(2, 3, 4),
+      StopStream,
+      AddPulsarData(Set(topic), 4, 5, 6), // Add data when stream is stopped
+      StartStream(),
+      CheckAnswer(2, 3, 4, 5, 6, 7), // Should get the added data
+      StopStream,
+      AddPulsarData(Set(topic), 7, 8),
+      StartStream(),
+      CheckAnswer(2, 3, 4, 5, 6, 7, 8, 9),
+    )
+  }
+
+  private def testFromEarliestOffsets(
+    topic: String,
+    addPartitions: Boolean,
+    failOnDataLoss: Boolean,
+    options: (String, String)*): Unit = {
+
+    sendMessages(topic, (1 to 3).map { _.toString }.toArray)
+    require(getLatestOffsets(Set(topic)).size === 1)
+
+    val reader = spark.readStream
+    reader
+      .format("pulsar")
+      .option(StartingOffsetsOptionKey, "earliest")
+      .option(ServiceUrlOptionKey, serviceUrl)
+      .option(FailOnDataLossOptionKey, failOnDataLoss.toString)
+    options.foreach { case (k, v) => reader.option(k, v) }
+    val pulsar = reader
+      .load()
+      .selectExpr("CAST(__key AS STRING)", "CAST(value AS STRING)")
+      .as[(String, String)]
+    val mapped = pulsar.map(kv => kv._2.toInt + 1)
+
+    testStream(mapped)(
+      StopStream,
+      AddPulsarData(Set(topic), 4, 5, 6), // Add data when stream is stopped
+      StartStream(),
+      CheckAnswer(2, 3, 4, 5, 6, 7),
+      StopStream,
+      AddPulsarData(Set(topic), 7, 8),
+      StartStream(),
+      CheckAnswer(2, 3, 4, 5, 6, 7, 8, 9),
+      StopStream,
+      AddPulsarData(Set(topic), 9, 10, 11, 12, 13, 14, 15, 16),
+      StartStream(),
+      CheckAnswer(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17)
+    )
+  }
+
+  private def testFromTime(
+    topic: String,
+    addPartitions: Boolean,
+    failOnDataLoss: Boolean,
+    options: (String, String)*): Unit = {
+
+    val time0 = System.currentTimeMillis() - 10000
+
+    sendMessages(topic, (1 to 3).map { _.toString }.toArray)
+    require(getLatestOffsets(Set(topic)).size === 1)
+
+    def dfAfter(ts: Long) = {
+      val reader = spark.readStream
+      reader
+        .format("pulsar")
+        .option(StartingTime, time0)
+        .option(ServiceUrlOptionKey, serviceUrl)
+        .option(FailOnDataLossOptionKey, failOnDataLoss.toString)
+      options.foreach { case (k, v) => reader.option(k, v) }
+      val pulsar = reader
+        .load()
+        .selectExpr("CAST(__key AS STRING)", "CAST(value AS STRING)")
+        .as[(String, String)]
+      val mapped = pulsar.map(kv => kv._2.toInt + 1)
+      mapped
+    }
+
+    testStream(dfAfter(time0))(
+      StopStream,
+      AddPulsarData(Set(topic), 7, 8, 9),
+      StartStream(),
+      CheckAnswer(2, 3, 4, 8, 9, 10)
+    )
+  }
+
+  private def testFromSpecificOffsets(
+    topic: String,
+    failOnDataLoss: Boolean,
+    options: (String, String)*): Unit = {
+
+    val mids = sendMessages(
+      topic,
+      Array(
+        //  0,   1,   2,  3, 4, 5,  6, 7,  8
+        -20, -21, -22, 1, 2, 3, 10, 11, 12).map(_.toString),
+      None).map(_._2)
+
+    val s1 = JsonUtils.topicOffsets(Map(topic -> mids(3)))
+
+    val reader = spark.readStream
+      .format("pulsar")
+      .option(StartingOffsetsOptionKey, s1)
+      .option(ServiceUrlOptionKey, serviceUrl)
+      .option(FailOnDataLossOptionKey, failOnDataLoss.toString)
+    options.foreach { case (k, v) => reader.option(k, v) }
+    val pulsar = reader
+      .load()
+      .selectExpr("CAST(__key AS STRING)", "CAST(value AS STRING)")
+      .as[(String, String)]
+    val mapped = pulsar.map(kv => kv._2.toInt)
+
+    testStream(mapped)(
+      StopStream,
+      AddPulsarData(Set(topic), 7),
+      StartStream(),
+      CheckAnswer(1, 2, 3, 10, 11, 12, 7),
+      StopStream,
+      AddPulsarData(Set(topic), 30, 31, 32, 33, 34),
+      StartStream(),
+      CheckAnswer(1, 2, 3, 10, 11, 12, 7, 30, 31, 32, 33, 34)
+    )
+  }
+}

--- a/src/test/scala/org/apache/spark/sql/pulsar/PulsarSinkSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/pulsar/PulsarSinkSuite.scala
@@ -13,9 +13,10 @@
  */
 package org.apache.spark.sql.pulsar
 
+import java.sql.Date
 import java.text.SimpleDateFormat
 import java.util.concurrent.atomic.AtomicInteger
-import java.util.{Date, Locale}
+import java.util.Locale
 import scala.reflect.ClassTag
 import org.scalatest.time.SpanSugar._
 import org.apache.pulsar.client.api.Schema
@@ -113,7 +114,7 @@ class PulsarSinkSuite extends StreamTest with PulsarTest with SharedSparkSession
     batchCheck[Date](
       Schema.DATE.getSchemaInfo,
       dateSeq,
-      Encoders.bean(classOf[Date]),
+      Encoders.DATE,
       dateFormat.format(_))
   }
 
@@ -367,9 +368,9 @@ class PulsarSinkSuite extends StreamTest with PulsarTest with SharedSparkSession
 
   test("streaming - write date") {
     val dateFormat = new SimpleDateFormat("yyyy-MM-dd")
-    streamCheck[java.sql.Date](
+    streamCheck[Date](
       Schema.DATE.getSchemaInfo,
-      dateSeq.map(d => new java.sql.Date(d.getTime)),
+      dateSeq,
       Encoders.DATE,
       dateFormat.format(_))
   }

--- a/src/test/scala/org/apache/spark/sql/pulsar/PulsarSourceSuiteBase.scala
+++ b/src/test/scala/org/apache/spark/sql/pulsar/PulsarSourceSuiteBase.scala
@@ -14,12 +14,11 @@
 package org.apache.spark.sql.pulsar
 
 import java.nio.charset.StandardCharsets.UTF_8
+import java.sql.Date
 import java.text.SimpleDateFormat
-import java.util.{Date, Locale}
+import java.util.Locale
 import scala.reflect.ClassTag
-import org.apache.pulsar.client.api.schema.GenericRecord
 import org.apache.pulsar.client.api.{MessageId, Schema}
-import org.apache.pulsar.client.impl.ConsumerImpl
 import org.apache.pulsar.common.schema.SchemaInfo
 import org.apache.spark.sql.execution.streaming.StreamExecution
 import org.apache.spark.sql.pulsar.PulsarProvider.getPulsarOffset
@@ -306,7 +305,7 @@ abstract class PulsarSourceSuiteBase extends PulsarSourceTest {
     check[Date](
       Schema.DATE.getSchemaInfo,
       dateSeq,
-      Encoders.bean(classOf[Date]),
+      Encoders.DATE,
       dateFormat.format(_))
   }
 

--- a/src/test/scala/org/apache/spark/sql/pulsar/PulsarSourceTest.scala
+++ b/src/test/scala/org/apache/spark/sql/pulsar/PulsarSourceTest.scala
@@ -100,8 +100,8 @@ class PulsarSourceTest extends StreamTest with SharedSparkSession with PulsarTes
         "Cannot add data when there is no query for finding the active pulsar source")
 
       val sources = query.get.logicalPlan.collect {
-          case StreamingExecutionRelation(source: PulsarSource, _) => source
-          case StreamingExecutionRelation(source: PulsarMicroBatchReader, _) => source
+          case StreamingExecutionRelation(source: PulsarSource, _, _) => source
+          case StreamingExecutionRelation(source: PulsarMicroBatchReader, _, _) => source
         }.distinct
 
       if (sources.isEmpty) {
@@ -159,8 +159,8 @@ class PulsarSourceTest extends StreamTest with SharedSparkSession with PulsarTes
         "Cannot add data when there is no query for finding the active pulsar source")
 
       val sources = query.get.logicalPlan.collect {
-          case StreamingExecutionRelation(source: PulsarSource, _) => source
-          case StreamingExecutionRelation(source: PulsarMicroBatchReader, _) => source
+          case StreamingExecutionRelation(source: PulsarSource, _, _) => source
+          case StreamingExecutionRelation(source: PulsarMicroBatchReader, _, _) => source
         }.distinct
 
       if (sources.isEmpty) {
@@ -191,7 +191,7 @@ class PulsarSourceTest extends StreamTest with SharedSparkSession with PulsarTes
 
   protected def newTopic(): String = TopicName.get(s"topic-${topicId.getAndIncrement()}").toString
 
-  override def testStream(_stream: Dataset[_], outputMode: OutputMode)(
+  override def testStream(_stream: Dataset[_], outputMode: OutputMode, extraOptions: Map[String,String])(
     actions: StreamAction*): Unit = synchronized {
     import org.apache.spark.sql.streaming.util.StreamManualClock
 

--- a/src/test/scala/org/apache/spark/sql/pulsar/SchemaData.scala
+++ b/src/test/scala/org/apache/spark/sql/pulsar/SchemaData.scala
@@ -29,7 +29,7 @@ object SchemaData {
   cal.clear()
   val dateSeq = (1 to 5).map { i =>
     cal.set(2019, 0, i)
-    cal.getTime
+    new java.sql.Date(cal.getTime.getTime)
   }
 
   cal.clear()


### PR DESCRIPTION
### Motivation

When start offset are serialized and deserialized, UserProvidedMessageId wrapper is dropped, which cause the first message to be skipped.
As we migrate to 3.4, we also want to add test coverage for available now trigger.

### Modifications

Fix data loss of initial batch by wrapping it in UserProvidedMessageId when deserializing the offset.
Add available now trigger test.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:

- [ ] This change added tests and can be verified as follows:

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required`
- [x] `no-need-doc`
- [ ] `doc`
