### PR TITLE
Adding PulsarAdmin configs to PulsarHelper

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,17 @@ Please check [Pulsar Client Configuration](https://pulsar.apache.org/docs/2.11.x
 </tr>
 
 <tr>
+  <td>`pulsar.admin.*`</td>
+  <td>Pulsar Admin configurations</td>
+  <td>No</td>
+  <td>None</td>
+  <td>Streaming and Batch</td>
+  <td>Admin configurations. Example: "pulsar.admin.tlsAllowInsecureConnection".
+
+Please check [Pulsar Admin Configuration](https://pulsar.apache.org/docs/2.10.x/admin-api-overview/) for more details </td>
+</tr>
+
+<tr>
   <td>`pulsar.reader.*`</td>
   <td>Pulsar Reader configurations</td>
   <td>No</td>

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarHelper.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarHelper.scala
@@ -136,6 +136,9 @@ private[pulsar] case class PulsarHelper(
       try {
         val (subscription, _) = extractSubscription(predefinedSubscription, tp)
         val consumer = CachedConsumer.getOrCreate(tp, subscription, client)
+        // We need to do this because the consumer does not attempt to
+        // reconnect after calling .seek().
+        // TODO: Remove this once we have upgraded to a version so that this is no longer needed
         if (!consumer.isConnected) consumer.getLastMessageId
         consumer.seek(mid)
       } catch {

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarHelper.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarHelper.scala
@@ -47,6 +47,7 @@ import org.apache.spark.sql.types.StructType
 private[pulsar] case class PulsarHelper(
     serviceUrl: String,
     adminUrl: Option[String],
+    adminConf: ju.Map[String, Object],
     clientConf: ju.Map[String, Object],
     driverGroupIdPrefix: String,
     caseInsensitiveParameters: Map[String, String],
@@ -66,7 +67,7 @@ private[pulsar] case class PulsarHelper(
   // will only be called if latestOffset is called and there should
   // be an exception thrown in PulsarProvider if maxBytes is set,
   // and adminUrl is not set
-  private lazy val admissionControlHelper = new PulsarAdmissionControlHelper(adminUrl.get)
+  private lazy val admissionControlHelper = new PulsarAdmissionControlHelper(adminUrl.get, adminConf)
 
   override def close(): Unit = {
     // do nothing
@@ -520,10 +521,10 @@ private[pulsar] case class PulsarHelper(
   }
 }
 
-class PulsarAdmissionControlHelper(adminUrl: String)
+class PulsarAdmissionControlHelper(adminUrl: String, conf: ju.Map[String, Object])
   extends Logging {
 
-  private lazy val pulsarAdmin = PulsarAdmin.builder().serviceHttpUrl(adminUrl).build()
+  private lazy val pulsarAdmin = PulsarAdmin.builder().serviceHttpUrl(adminUrl).loadConf(conf).build()
 
   import scala.collection.JavaConverters._
 

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarHelper.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarHelper.scala
@@ -67,7 +67,8 @@ private[pulsar] case class PulsarHelper(
   // will only be called if latestOffset is called and there should
   // be an exception thrown in PulsarProvider if maxBytes is set,
   // and adminUrl is not set
-  private lazy val admissionControlHelper = new PulsarAdmissionControlHelper(adminUrl.get, adminConf)
+  private lazy val admissionControlHelper = new
+      PulsarAdmissionControlHelper(adminUrl.get, adminConf)
 
   override def close(): Unit = {
     // do nothing
@@ -524,7 +525,8 @@ private[pulsar] case class PulsarHelper(
 class PulsarAdmissionControlHelper(adminUrl: String, conf: ju.Map[String, Object])
   extends Logging {
 
-  private lazy val pulsarAdmin = PulsarAdmin.builder().serviceHttpUrl(adminUrl).loadConf(conf).build()
+  private lazy val pulsarAdmin =
+    PulsarAdmin.builder().serviceHttpUrl(adminUrl).loadConf(conf).build()
 
   import scala.collection.JavaConverters._
 

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarOptions.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarOptions.scala
@@ -22,6 +22,7 @@ private[pulsar] object PulsarOptions {
 
   // option key prefix for different modules
   val PulsarClientOptionKeyPrefix: String = "pulsar.client."
+  val PulsarAdminOptionKeyPrefix: String = "pulsar.admin."
   val PulsarProducerOptionKeyPrefix: String = "pulsar.producer."
   val PulsarReaderOptionKeyPrefix: String = "pulsar.reader."
 

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarProvider.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarProvider.scala
@@ -115,11 +115,6 @@ private[pulsar] class PulsarProvider
         "must be specified if maxBytesPerTrigger is specified")
     }
 
-    if (adminUrl.isEmpty && !adminConfig.isEmpty) {
-      throw new IllegalArgumentException("admin.url " +
-        "must be specified if admin options are specified")
-    }
-
     new PulsarSource(
       sqlContext,
       pulsarHelper,

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarProvider.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarProvider.scala
@@ -56,7 +56,8 @@ private[pulsar] class PulsarProvider
       parameters: Map[String, String]): (String, StructType) = {
 
     val caseInsensitiveParams = validateStreamOptions(parameters)
-    val (clientConfig, _, adminConfig, serviceUrlConfig, adminUrl) = prepareConfForReader(parameters)
+    val (clientConfig, _, adminConfig,
+      serviceUrlConfig, adminUrl) = prepareConfForReader(parameters)
 
     val subscriptionNamePrefix = s"spark-pulsar-${UUID.randomUUID}"
     val inferredSchema = Utils.tryWithResource(
@@ -86,7 +87,9 @@ private[pulsar] class PulsarProvider
     logDebug(s"Creating Pulsar source: $parameters")
 
     val caseInsensitiveParams = validateStreamOptions(parameters)
-    val (clientConfig, readerConfig, adminConfig, serviceUrl, adminUrl) = prepareConfForReader(parameters)
+    val (clientConfig, readerConfig,
+      adminConfig, serviceUrl, adminUrl) = prepareConfForReader(parameters)
+
     logDebug(
       s"Client config: $clientConfig; Reader config: $readerConfig; Service URL: $serviceUrl")
 
@@ -136,7 +139,9 @@ private[pulsar] class PulsarProvider
 
     val subscriptionNamePrefix = getSubscriptionPrefix(parameters, isBatch = true)
 
-    val (clientConfig, readerConfig, adminConfig, serviceUrl, adminUrl) = prepareConfForReader(parameters)
+    val (clientConfig, readerConfig,
+      adminConfig, serviceUrl, adminUrl) = prepareConfForReader(parameters)
+
     val (start, end, schema, pSchema) = Utils.tryWithResource(
       PulsarHelper(
         serviceUrl,
@@ -514,7 +519,8 @@ private[pulsar] object PulsarProvider extends Logging {
   }
 
   private def prepareConfForReader(parameters: Map[String, String])
-      : (ju.Map[String, Object], ju.Map[String, Object], ju.Map[String, Object], String, Option[String]) = {
+      : (ju.Map[String, Object], ju.Map[String, Object],
+        ju.Map[String, Object], String, Option[String]) = {
 
     val serviceUrl = getServiceUrl(parameters)
     val adminUrl = getAdminUrl(parameters)

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarProvider.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarProvider.scala
@@ -262,17 +262,7 @@ private[pulsar] object PulsarProvider extends Logging {
   }
 
   private def getAdminParams(parameters: Map[String, String]): Map[String, String] = {
-    val lowercaseKeyMap = parameters.keySet
-      .filter(_.startsWith(PulsarAdminOptionKeyPrefix))
-      .map { k =>
-        k.drop(PulsarAdminOptionKeyPrefix.length).toString -> parameters(k)
-      }
-      .toMap
-    lowercaseKeyMap.map { case (k, v) =>
-      clientConfKeys.getOrElse(
-        k,
-        throw new IllegalArgumentException(s"$k not supported by pulsar")) -> v
-    }
+    getModuleParams(parameters, PulsarAdminOptionKeyPrefix, clientConfKeys)
   }
 
   private def getProducerParams(parameters: Map[String, String]): Map[String, String] = {

--- a/src/test/scala/org/apache/spark/sql/pulsar/PulsarAdmissionControlSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/pulsar/PulsarAdmissionControlSuite.scala
@@ -1,5 +1,7 @@
 package org.apache.spark.sql.pulsar
 
+import java.{util => ju}
+
 import org.apache.pulsar.client.admin.PulsarAdmin
 import org.apache.pulsar.client.api.MessageId
 import org.apache.pulsar.client.internal.DefaultImplementation
@@ -33,7 +35,7 @@ class PulsarAdmissionControlSuite extends PulsarSourceTest {
     val firstLedger = getLedgerId(firstMid)
     val firstEntry = getEntryId(firstMid)
     require(getLatestOffsets(Set(topic)).size === 1)
-    val admissionControlHelper = new PulsarAdmissionControlHelper(adminUrl)
+    val admissionControlHelper = new PulsarAdmissionControlHelper(adminUrl, new ju.HashMap[String, Object]())
     val offset = admissionControlHelper.latestOffsetForTopicPartition(topic, MessageId.earliest, approxSizeOfInt)
     assert(getLedgerId(offset) == firstLedger && getEntryId(offset) == firstEntry)
   }
@@ -44,7 +46,7 @@ class PulsarAdmissionControlSuite extends PulsarSourceTest {
     val firstMid = messageIds.head._2
     val secondMid = messageIds.apply(1)._2
     require(getLatestOffsets(Set(topic)).size === 1)
-    val admissionControlHelper = new PulsarAdmissionControlHelper(adminUrl)
+    val admissionControlHelper = new PulsarAdmissionControlHelper(adminUrl, new ju.HashMap[String, Object]())
     val offset = admissionControlHelper.latestOffsetForTopicPartition(topic, firstMid, approxSizeOfInt)
     assert(getLedgerId(offset) == getLedgerId(secondMid) && getEntryId(offset) == getEntryId(secondMid))
 

--- a/src/test/scala/org/apache/spark/sql/pulsar/PulsarAdmissionControlSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/pulsar/PulsarAdmissionControlSuite.scala
@@ -28,6 +28,18 @@ class PulsarAdmissionControlSuite extends PulsarSourceTest {
     super.afterAll()
   }
 
+  test("Only admit first entry of ledger") {
+    val topic = newTopic()
+    val messageIds = sendMessages(topic, Array("1", "2", "3"))
+    val firstMid = messageIds.head._2
+    val firstLedger = getLedgerId(firstMid)
+    val firstEntry = getEntryId(firstMid)
+    require(getLatestOffsets(Set(topic)).size === 1)
+    val admissionControlHelper = new PulsarAdmissionControlHelper(adminUrl, new ju.HashMap[String, Object]())
+    val offset = admissionControlHelper.latestOffsetForTopicPartition(topic, MessageId.earliest, approxSizeOfInt)
+    assert(getLedgerId(offset) == firstLedger && getEntryId(offset) == firstEntry)
+  }
+
   test("setting invalid config PulsarAdmin") {
     val conf = new ju.HashMap[String, Object]()
     conf.put("INVALID", "INVALID")
@@ -40,6 +52,79 @@ class PulsarAdmissionControlSuite extends PulsarSourceTest {
       admissionControlHelper.latestOffsetForTopicPartition(topic, MessageId.earliest, approxSizeOfInt)
     }
     assert(e.getMessage.contains("Failed to load config into existing configuration data"))
+  }
+
+  test("Admit entry in the middle of the ledger") {
+    val topic = newTopic()
+    val messageIds = sendMessages(topic, Array("1", "2", "3"))
+    val firstMid = messageIds.head._2
+    val secondMid = messageIds.apply(1)._2
+    require(getLatestOffsets(Set(topic)).size === 1)
+    val admissionControlHelper = new PulsarAdmissionControlHelper(adminUrl, new ju.HashMap[String, Object]())
+    val offset = admissionControlHelper.latestOffsetForTopicPartition(topic, firstMid, approxSizeOfInt)
+    assert(getLedgerId(offset) == getLedgerId(secondMid) && getEntryId(offset) == getEntryId(secondMid))
+
+  }
+
+  test("Check last batch where message size is greater than maxBytesPerTrigger") {
+    val topic = newTopic()
+    sendMessages(topic, Array("-1"))
+    require(getLatestOffsets(Set(topic)).size === 1)
+
+    val pulsar = spark.readStream
+      .format("pulsar")
+      .option(TopicSingle, topic)
+      .option(ServiceUrlOptionKey, serviceUrl)
+      .option(AdminUrlOptionKey, adminUrl)
+      .option(FailOnDataLossOptionKey, "true")
+      .option(MaxBytesPerTrigger, approxSizeOfInt * 3)
+      .load()
+      .selectExpr("CAST(__key AS STRING)", "CAST(value AS STRING)")
+      .as[(String, String)]
+
+    val mapped = pulsar.map(kv => kv._2.toInt + 1)
+
+    testStream(mapped)(
+      StartStream(trigger = ProcessingTime(1000)),
+      makeSureGetOffsetCalled,
+      AddPulsarData(Set(topic), 1, 2, 3),
+      AddPulsarData(Set(topic), 4, 5, 6, 7, 8, 9),
+      AssertOnQuery { query =>
+        query.recentProgress.map(microBatch =>
+          microBatch.numInputRows <= 4
+        ).forall(_ == true)
+      }
+    )
+  }
+
+  test("Admission Control for multiple topics") {
+    val topic1 = newTopic()
+    val topic2 = newTopic()
+
+    val pulsar = spark.readStream
+      .format("pulsar")
+      .option(TopicMulti, s"$topic1,$topic2")
+      .option(ServiceUrlOptionKey, serviceUrl)
+      .option(AdminUrlOptionKey, adminUrl)
+      .option(FailOnDataLossOptionKey, "true")
+      .option(MaxBytesPerTrigger, approxSizeOfInt * 6)
+      .load()
+      .selectExpr("CAST(__key AS STRING)", "CAST(value AS STRING)")
+      .as[(String, String)]
+
+    val mapped = pulsar.map(kv => kv._2.toInt + 1)
+
+    testStream(mapped)(
+      StartStream(trigger = ProcessingTime(1000)),
+      makeSureGetOffsetCalled,
+      AddPulsarData(Set(topic1), 1, 2, 3),
+      AddPulsarData(Set(topic2), 4, 5, 6, 7, 8, 9),
+      AssertOnQuery { query =>
+        query.recentProgress.map(microBatch =>
+          microBatch.numInputRows <= 4
+        ).forall(_ == true)
+      }
+    )
   }
 
   test("Admission Control for concurrent topic writes") {


### PR DESCRIPTION
### Motivation
In #151 we added `admin.url` without adding Admin Confs. 

### Modifications

*Describe the modifications you've done.*

Basically reverting #120 
### Verifying this change

- [ x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

- [ x] This change is a trivial rework / code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:

- [ ] This change added tests and can be verified as follows:

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required`
- [x] `no-need-doc`
- [ ] `doc`
