### PR TITLE
Remove redundant get Stats call

### DIFF
--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarHelper.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarHelper.scala
@@ -530,8 +530,7 @@ class PulsarAdmissionControlHelper(adminUrl: String)
     val startLedgerId = getLedgerId(startMessageId)
     val startEntryId = getEntryId(startMessageId)
     val stats = pulsarAdmin.topics.getInternalStats(topicPartition)
-    val ledgers = pulsarAdmin.topics.getInternalStats(topicPartition).ledgers.
-      asScala.filter(_.ledgerId >= startLedgerId).sortBy(_.ledgerId)
+    val ledgers = stats.ledgers.asScala.filter(_.ledgerId >= startLedgerId).sortBy(_.ledgerId)
     // The last ledger of the ledgers list doesn't have .size or .entries
     // properly populated, and the corresponding info is in currentLedgerSize
     // and currentLedgerEntries


### PR DESCRIPTION
### Motivation

There is a redundant getStats call in Pulsar admin control

### Modifications

Remove the redundant call.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:

- [ ] This change added tests and can be verified as follows:

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required`
- [x] `no-need-doc`
- [ ] `doc`
