### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,6 @@ You can use `org.apache.spark.sql.pulsar.JsonUtils.topicOffsets(Map[String, Mess
   "earliest".
   </td>
 </tr>
-
 <tr>
   <td>`endingOffsets`</td>
   <td>The following are valid values:<br>
@@ -375,6 +374,30 @@ You can use `org.apache.spark.sql.pulsar.JsonUtils.topicOffsets(Map[String, Mess
 
     `MessageId.earliest ([8,-1,-1,-1,-1,-1,-1,-1,-1,-1,1,16,-1,-1,-1,-1,-1,-1,-1,-1,-1,1])` is not allowed.
   </td>
+</tr>
+<tr>
+    <td>`startingTime`</td>
+    <td> A number in unit of milliseconds </td>
+    <td>No</td>
+    <td>None</td>
+    <td>batch queries</td>
+    <td>
+       For batch query, You can set a starting offset using milliseconds. <br>
+       The target time of this option is publishTime. <br>
+       Example: `1709254800000` (2024-03-01 01:00:00)
+    </td>
+</tr>
+<tr>
+    <td>`endingTime`</td>
+    <td> A number in unit of milliseconds </td>
+    <td>No</td>
+    <td>None</td>
+    <td>batch queries</td>
+    <td>
+       For batch query, You can set a ending offset using milliseconds. <br>
+       The target time of this option is publishTime. <br>
+       Example: `1709254800000` (2024-03-01 02:00:00)
+    </td>
 </tr>
 
 <tr>


### PR DESCRIPTION
### Motivation

Since you haven't updated Readme, we have spent so long time to found out how to read data within specific range. 
Thankfully, we found options(`startingTime` ,`endingTime`)  to solve our issue in [PulsarOptions.scala](https://github.com/streamnative/pulsar-spark/blob/master/src/main/scala/org/apache/spark/sql/pulsar/PulsarOptions.scala#L42).
We would like to share the existence of these options. 

### Modifications

Added startingTime and endingTime options for configurations.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

- [x] This change is a trivial rework / code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:

- [ ] This change added tests and can be verified as follows:

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required`
- [ ] `no-need-doc`
- [x] `doc`
