### PR TITLE
shade bouncy castle so there are no conflicts with user libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -428,6 +428,10 @@
                   <pattern>org.lz4</pattern>
                   <shadedPattern>org.apache.pulsar.shade.org.lz4</shadedPattern>
                 </relocation>
+                <relocation>
+                  <pattern>org.bouncycastle</pattern>
+                  <shadedPattern>org.apache.pulsar.shade.org.bouncycastle</shadedPattern>
+                </relocation>
               </relocations>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />


### PR DESCRIPTION
### Motivation

BouncyCastle which is a dependency from pulsar client is not shaded.  This can cause conflicts with user libraries that users need to use in their streaming queries.

### Modifications

shade bouncy castle 

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:

- [ ] This change added tests and can be verified as follows:

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required`
- [x] `no-need-doc`
- [ ] `doc`
