### PR TITLE
Removing using problematic "seek" API and adding additional debug messages

### DIFF
--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarOffset.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarOffset.scala
@@ -34,6 +34,12 @@ private[pulsar] case class SpecificPulsarOffset(topicOffsets: Map[String, Messag
     with PerTopicOffset {
 
   override val json = JsonUtils.topicOffsets(topicOffsets)
+
+  override def toString: String = {
+    s"SpecificPulsarOffset(${topicOffsets.map { case (topic, offset) =>
+      s"$topic: ${offset.toString} (${offset.getClass}"
+    }.mkString(", ")})"
+  }
 }
 
 private[pulsar] case class SpecificPulsarTime(topicTimes: Map[String, Long])

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarSource.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarSource.scala
@@ -88,7 +88,7 @@ private[pulsar] class PulsarSource(
   override def latestOffset(startingOffset: streaming.Offset,
                             readLimit: ReadLimit): streaming.Offset = {
     initialTopicOffsets
-    readLimit match {
+    val offset = readLimit match {
       case ReadMaxBytes(maxBytes) =>
         startingOffset match {
           // deals with the case where we add a topic-partition after
@@ -99,6 +99,8 @@ private[pulsar] class PulsarSource(
         }
       case _: ReadAllAvailable => pulsarHelper.fetchLatestOffsets()
     }
+    logDebug(s"Got latest offset $offset with starting offset as ${startingOffset}")
+    offset
   }
   override def getDefaultReadLimit: ReadLimit = {
     if (maxBytesPerTrigger == 0L) {
@@ -112,7 +114,6 @@ private[pulsar] class PulsarSource(
     // Make sure initialTopicOffsets is initialized
     initialTopicOffsets
 
-    logInfo(s"getBatch called with start = $start, end = $end")
     val endTopicOffsets = SpecificPulsarOffset.getTopicOffsets(end)
 
     if (currentTopicOffsets.isEmpty) {

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarSource.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarSource.scala
@@ -114,6 +114,7 @@ private[pulsar] class PulsarSource(
     // Make sure initialTopicOffsets is initialized
     initialTopicOffsets
 
+    logInfo(s"getBatch called with start = $start, end = $end")
     val endTopicOffsets = SpecificPulsarOffset.getTopicOffsets(end)
 
     if (currentTopicOffsets.isEmpty) {

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarSourceRDD.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarSourceRDD.scala
@@ -60,6 +60,14 @@ private[pulsar] abstract class PulsarSourceRDDBase(
     val deserializer = new PulsarDeserializer(schemaInfo.si, jsonOptions)
     val schema: Schema[_] = SchemaUtils.getPSchema(schemaInfo.si)
 
+    if (isTraceEnabled()) {
+      logTrace(
+        s" Start reading from topic ${topic}" +
+        s" with subscription prefix ${subscriptionNamePrefix}" +
+        s" from startOffset: ${startOffset} to endOffset: ${endOffset}"
+      )
+    }
+
     lazy val reader = PulsarClientFactory
       .getOrCreate(pulsarClientFactoryClassName, clientConf)
       .newReader(schema)
@@ -96,18 +104,20 @@ private[pulsar] abstract class PulsarSourceRDDBase(
                 s"Potential Data Loss: intended to start at $startOffset, " +
                   s"actually we get $currentId")
             }
+            if (isTraceEnabled()) {
+              logTrace(s"First message read has id ${currentId}")
+            }
 
             (startOffset, currentId) match {
               case (_: BatchMessageIdImpl, _: BatchMessageIdImpl) =>
               // we seek using a batch message id, we can read next directly in `getNext()`
               case (_: MessageIdImpl, cbmid: BatchMessageIdImpl) =>
-                // we seek using a message id, this is supposed to be read by previous task since
-                // it's inclusive for the last batch (start, end], so we skip this batch
-                val newStart = new MessageIdImpl(
-                  cbmid.getLedgerId,
-                  cbmid.getEntryId + 1,
-                  cbmid.getPartitionIndex)
-                reader.seek(newStart)
+                // We can only really get to this scenario
+                // when producers sent a batched message will a single record.
+                // The reader will read a batched message but the message id
+                // returned by getLastMessageId() will return a MessageIdImpl.
+                assert(cbmid.getBatchIndex == 0,
+                  s"Batch index should be 0, but got ${cbmid.getBatchIndex}")
               case (smid: MessageIdImpl, cmid: MessageIdImpl) =>
               // current entry is a non-batch entry, we can read next directly in `getNext()`
             }
@@ -124,18 +134,76 @@ private[pulsar] abstract class PulsarSourceRDDBase(
           throw e
       }
 
+      private def processDataLoss(
+          currentMessageId: MessageId,
+          previousMessageId: MessageId): Unit = {
+
+        reportDataLoss(
+          s"Unexpected message skipping was detected:" +
+            s" Previous message id was $previousMessageId," +
+            s" however the current message read has id $currentMessageId"
+        )
+      }
+
+      /**
+       * Detect data loss by comparing the current message id with the previous message id.
+       * Make sure invariants are held
+       */
+      private def detectDataLoss(
+          currentMessageId: MessageId,
+          previousMessageId: MessageId): Unit = {
+        (currentMessageId, previousMessageId) match {
+          case (c: BatchMessageIdImpl, p: BatchMessageIdImpl) =>
+            if (c.getLedgerId == p.getLedgerId) {
+              if (c.getEntryId == p.getEntryId) {
+                if (c.getBatchIndex != p.getBatchIndex + 1) {
+                  processDataLoss(c, p)
+                }
+              } else if (c.getEntryId == p.getEntryId + 1) {
+                // if we have moved to ready the next entry
+                // the batch index should be 0, i.e. to first record
+                // in the entry / batch
+                if (c.getBatchIndex != 0) {
+                  processDataLoss(c, p)
+                }
+              } else if (c.getEntryId != p.getEntryId + 1) {
+                processDataLoss(c, p)
+              }
+            }
+          case (c: MessageIdImpl, p: BatchMessageIdImpl) =>
+            if (c.getLedgerId == p.getLedgerId && c.getEntryId != p.getEntryId + 1) {
+              processDataLoss(c, p)
+            }
+
+          case (c: MessageIdImpl, p: MessageIdImpl) =>
+            // if we are still reading from the same ledger, the next message we read
+            // should be the next entry in the ledger
+            if (c.getLedgerId == p.getLedgerId && c.getEntryId != p.getEntryId + 1) {
+              processDataLoss(c, p)
+            }
+        }
+      }
+
       override protected def getNext(): InternalRow = {
         try {
           if (isLast) {
             finished = true
             return null
           }
+          val prevMessage = currentMessage
           currentMessage = reader.readNext(pollTimeoutMs, TimeUnit.MILLISECONDS)
           if (currentMessage == null) {
             reportDataLoss(
               s"We didn't get enough message as promised from topic $topic, data loss occurs")
             finished = true
             return null
+          }
+
+          // check for any data skipping
+          val currentMessageId = currentMessage.getMessageId
+          if (prevMessage != null) {
+            val previousMessageId = prevMessage.getMessageId
+            detectDataLoss(currentMessageId, previousMessageId)
           }
 
           rowsBytesAccumulator.foreach(_.add(currentMessage.size()))
@@ -145,6 +213,14 @@ private[pulsar] abstract class PulsarSourceRDDBase(
           inEnd = enterEndFunc(currentId)
           if (inEnd) {
             isLast = isLastMessage(currentId)
+          }
+
+          if (isTraceEnabled()) {
+            logTrace(
+              s"Read message:" +
+              s" currentId=${currentId}" +
+              s" isLast:$isLast, inEnd:$inEnd"
+            )
           }
           deserializer.deserialize(currentMessage)
         } catch {

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarSourceRDD.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarSourceRDD.scala
@@ -170,10 +170,25 @@ private[pulsar] abstract class PulsarSourceRDDBase(
                 processDataLoss(c, p)
               }
             }
+
+          case (c: MessageIdImpl, p: BatchMessageIdImpl) =>
+            if (c.getLedgerId == p.getLedgerId) {
+              if (c.getEntryId != p.getEntryId + 1) {
+                processDataLoss(c, p)
+              } else {
+                // make sure the last message read was the last message
+                // in the previous batch message.
+                if (p.getBatchIndex == p.getBatchSize - 1) {
+                  processDataLoss(c, p)
+                }
+              }
+            }
+
           case (c: MessageIdImpl, p: BatchMessageIdImpl) =>
             if (c.getLedgerId == p.getLedgerId && c.getEntryId != p.getEntryId + 1) {
               processDataLoss(c, p)
             }
+
 
           case (c: MessageIdImpl, p: MessageIdImpl) =>
             // if we are still reading from the same ledger, the next message we read

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarSourceRDD.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarSourceRDD.scala
@@ -178,7 +178,7 @@ private[pulsar] abstract class PulsarSourceRDDBase(
               } else {
                 // make sure the last message read was the last message
                 // in the previous batch message.
-                if (p.getBatchIndex == p.getBatchSize - 1) {
+                if (p.getBatchIndex != p.getBatchSize - 1) {
                   processDataLoss(c, p)
                 }
               }

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -12,7 +12,7 @@
 # limitations under the License.
 #
 
-log4j.rootCategory=WARN, console
+log4j.rootCategory=INFO, console
 
 # Tests that launch java subprocesses can set the "test.appender" system property to
 # "console" to avoid having the child process's logs overwrite the unit test's

--- a/src/test/scala/org/apache/spark/sql/pulsar/PulsarTest.scala
+++ b/src/test/scala/org/apache/spark/sql/pulsar/PulsarTest.scala
@@ -49,7 +49,7 @@ trait PulsarTest extends BeforeAndAfterAll with BeforeAndAfterEach {
   self: SparkFunSuite =>
   import PulsarOptions._
 
-  val CURRENT_VERSION = "2.10.2"
+  val CURRENT_VERSION = "3.0.6"
 
   var pulsarContainer: PulsarContainer = null
   var serviceUrl: String = null
@@ -132,7 +132,8 @@ trait PulsarTest extends BeforeAndAfterAll with BeforeAndAfterEach {
   def sendMessages(
       topic: String,
       messages: Array[String],
-      partition: Option[Int]): Seq[(String, MessageId)] = {
+      partition: Option[Int],
+      batched: Boolean = false): Seq[(String, MessageId)] = {
 
     val topicName = if (partition.isEmpty) topic else s"$topic$PartitionSuffix${partition.get}"
 
@@ -144,10 +145,23 @@ trait PulsarTest extends BeforeAndAfterAll with BeforeAndAfterEach {
     val producer = client.newProducer().topic(topicName).create()
 
     val offsets = try {
-      messages.map { m =>
-        val mid = producer.send(m.getBytes(StandardCharsets.UTF_8))
-        logInfo(s"\t Sent $m of mid: $mid")
-        (m, mid)
+      if (batched) {
+        messages.map { m =>
+            (m, producer.sendAsync(m.getBytes(StandardCharsets.UTF_8)))
+          }
+          .collect {
+            case (m, future) =>
+              val mid = future.get()
+              logInfo(s"\t Sent $m of mid: $mid class: ${mid.getClass}")
+              (m, mid)
+          }
+          .toSeq
+      } else {
+        messages.map { m =>
+          val mid = producer.send(m.getBytes(StandardCharsets.UTF_8))
+          logInfo(s"\t Sent $m of mid: $mid class: ${mid.getClass}")
+          (m, mid)
+        }.toSeq
       }
     } finally {
       producer.flush()


### PR DESCRIPTION

### Motivation

The seek API has been historical problematic and buggy.  We have seen instances where calling seek to an message id did not actually move the read cursor to the correct message id.  It skipped some messages causing data to be lost.  Lets remove using this problematic API since it is not really needed to beginning with.

### Modifications

Remove using the Seek API and adding additional debugging logs and invariant checking

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:

- [ ] This change added tests and can be verified as follows:

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required`
- [x] `no-need-doc`
- [ ] `doc`
