### PR TITLE
Migrate nexus staging to nexus central

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           nexus_username: ${{ secrets.SONATYPE_USERNAME }}
           nexus_password: ${{ secrets.SONATYPE_PASSWORD }}
-          server_id: ossrh
+          server_id: central
           maven_profiles: release
           maven_goals_phases: clean deploy
           maven_args: -DskipTests

--- a/pom.xml
+++ b/pom.xml
@@ -506,16 +506,6 @@
       <url>https://repo1.maven.org/maven2</url>
     </repository>
   </repositories>
-  <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <repository>
-      <id>ossrh</id>
-      <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-  </distributionManagement>
   <profiles>
     <profile>
       <id>release</id>
@@ -541,14 +531,13 @@
             </configuration>
           </plugin>
           <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>${nexus-staging-maven-plugin.version}</version>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.7.0</version>
             <extensions>true</extensions>
             <configuration>
-              <serverId>ossrh</serverId>
-              <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-              <autoReleaseAfterClose>true</autoReleaseAfterClose>
+              <publishingServerId>central</publishingServerId>
+              <autoPublish>true</autoPublish>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
### Motivation

> The OSSRH service will reach end-of-life on [June 30th, 2025](https://central.sonatype.org/news/20250326_ossrh_sunset/). Learn more about how to transfer to the Central Publishing Portal [here](https://central.sonatype.org/faq/what-is-different-between-central-portal-and-legacy-ossrh/#process-to-migrate).

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:

- [ ] This change added tests and can be verified as follows:

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required`
- [x] `no-need-doc`
- [ ] `doc`
