### PR TITLE
Don't log the whole client configurations for security

### DIFF
--- a/src/main/scala/org/apache/spark/sql/pulsar/CachedPulsarClient.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/CachedPulsarClient.scala
@@ -44,7 +44,6 @@ private[pulsar] object CachedPulsarClient extends Logging {
       val clientConf =
         PulsarConfigUpdater("pulsarClientCache", config.asScala.toMap, PulsarOptions.FilteredKeys)
           .rebuild()
-      logInfo(s"Client Conf = ${clientConf}")
 
       val builder = PulsarClient.builder()
       try {

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarConfigUpdater.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarConfigUpdater.scala
@@ -76,18 +76,12 @@ private[pulsar] case class PulsarConfigUpdater(
     map
   }
 
-  private val HideCompletelyLimit = 6
-  private val ShowFractionOfHiddenValue = 1.0 / 3.0
   private val CompletelyHiddenMessage = "...<completely hidden>..."
 
   private def printConfigValue(key: String, maybeVal: Option[Object]): String = {
     val value = maybeVal.map(_.toString).getOrElse("")
     if (keysToHideInLog.contains(key)) {
-      if (value.length < HideCompletelyLimit) {
-        return CompletelyHiddenMessage
-      } else {
-        return s"${value.take((value.length * ShowFractionOfHiddenValue).toInt)}..."
-      }
+      return CompletelyHiddenMessage
     }
 
     value


### PR DESCRIPTION
### Motivation

https://github.com/streamnative/pulsar-spark/blob/59066fc68d73ddfd3bbfe5aec638543d5ea9b0da/src/main/scala/org/apache/spark/sql/pulsar/CachedPulsarClient.scala#L47

The whole client configurations are logged, which might include the secret info whose key is `authParams`.

### Modifications

Remove the logging for the whole client configuration. Actually, in `PulsarConfigUpdater.rebuild`, `set` will be called on each configuration, which is already logged here: https://github.com/streamnative/pulsar-spark/blob/59066fc68d73ddfd3bbfe5aec638543d5ea9b0da/src/main/scala/org/apache/spark/sql/pulsar/PulsarConfigUpdater.scala#L43-L46

The `printConfigValue` method will hide the config of `authParams`, but it could still print 1/3 of the `authParams`, which could still leak some info, so just hide the whole `authParams`

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required`
- [x] `no-need-doc`
- [ ] `doc`
