### PR TITLE
Upgrade to Spark 4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,6 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 17
       - name: Maven verify
         run: ./mvnw clean verify

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 1.8
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 17
 
       - uses: actions/checkout@v2
         with:

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Unified data processing with [Apache Pulsar](https://pulsar.apache.org) and [Apa
 ## Prerequisites
 
 - Java 8 or later
-- Spark 3.4.0 or later
-- Pulsar 2.10.2 or later
+- Spark 4.0.1 or later
+- Pulsar 3.0 or later
 
 ## Preparations
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Unified data processing with [Apache Pulsar](https://pulsar.apache.org) and [Apa
 
 ## Prerequisites
 
-- Java 8 or later
+- Java 17 or later
 - Spark 4.0.1 or later
 - Pulsar 3.0 or later
 
@@ -626,7 +626,7 @@ $ cd pulsar-spark
 $ mvn clean install -DskipTests
 ```
 
-If you get the following error during compilation, try running Maven with Java 8:  
+If you get the following error during compilation, try running Maven with Java 17:  
 ```
 [ERROR] [Error] : Source option 6 is no longer supported. Use 7 or later.
 [ERROR] [Error] : Target option 6 is no longer supported. Use 7 or later.

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
   <groupId>io.streamnative.connectors</groupId>
   <artifactId>pulsar-spark-connector_2.13</artifactId>
-  <version>3.5.6-SNAPSHOT</version>
+  <version>4.0.1-SNAPSHOT</version>
   <name>StreamNative :: Pulsar Spark Connector</name>
   <url>https://pulsar.apache.org</url>
   <inceptionYear>2019</inceptionYear>
@@ -67,14 +67,14 @@
     <!-- dependencies -->
     <!-- latest version from apache pulsar -->
     <pulsar.version>4.0.5</pulsar.version>
-    <scala.version>2.13.12</scala.version>
+    <scala.version>2.13.16</scala.version>
     <scala.binary.version>2.13</scala.binary.version>
     <scalatest.version>3.2.14</scalatest.version>
-    <spark.version>3.5.6</spark.version>
+    <spark.version>4.0.1</spark.version>
     <commons-io.version>2.19.0</commons-io.version>
     <testcontainers.version>1.18.3</testcontainers.version>
     <bouncycastle.version>1.78</bouncycastle.version>
-    <jackson.version>2.15.2</jackson.version>
+    <jackson.version>2.18.5</jackson.version>
 
     <!-- plugin dependencies -->
     <maven.version>3.5.4</maven.version>
@@ -89,6 +89,28 @@
     <scalatest-maven-plugin.version>2.2.0</scalatest-maven-plugin.version>
     <scalastyle-maven-plugin.version>1.0.0</scalastyle-maven-plugin.version>
     <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
+
+    <!-- SPARK-36796 for JDK-17 test-->
+    <extraJavaTestArgs>
+      -XX:+IgnoreUnrecognizedVMOptions
+      --add-modules=jdk.incubator.vector
+      --add-opens=java.base/java.lang=ALL-UNNAMED
+      --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
+      --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
+      --add-opens=java.base/java.io=ALL-UNNAMED
+      --add-opens=java.base/java.net=ALL-UNNAMED
+      --add-opens=java.base/java.nio=ALL-UNNAMED
+      --add-opens=java.base/java.util=ALL-UNNAMED
+      --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
+      --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED
+      --add-opens=java.base/jdk.internal.ref=ALL-UNNAMED
+      --add-opens=java.base/sun.nio.ch=ALL-UNNAMED
+      --add-opens=java.base/sun.nio.cs=ALL-UNNAMED
+      --add-opens=java.base/sun.security.action=ALL-UNNAMED
+      --add-opens=java.base/sun.util.calendar=ALL-UNNAMED
+      -Djdk.reflect.useDirectMethodHandle=false
+      -Dio.netty.tryReflectionSetAccessible=true
+    </extraJavaTestArgs>
   </properties>
 
   <!-- dependencies for all modules -->
@@ -379,6 +401,7 @@
           <systemProperties>
             <log4j.configuration>file:src/test/resources/log4j.properties</log4j.configuration>
           </systemProperties>
+          <argLine>${extraJavaTestArgs}</argLine>
         </configuration>
         <executions>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -56,9 +56,9 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <project.scm.id>snbot-github</project.scm.id>
-    <javac.target>1.8</javac.target>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <javac.target>17</javac.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
     <redirectTestOutputToFile>true</redirectTestOutputToFile>
     <testRetryCount>2</testRetryCount>
     <!-- for now, not running scalafmt as part of default verify pipeline -->
@@ -371,7 +371,7 @@
         <configuration>
           <scalaVersion>${scala.version}</scalaVersion>
           <args>
-            <arg>-target:jvm-1.8</arg>
+            <arg>-target:jvm-17</arg>
             <arg>-unchecked</arg>
             <arg>-deprecation</arg>
             <arg>-feature</arg>

--- a/src/main/resources/error/pulsar-error-classes.json
+++ b/src/main/resources/error/pulsar-error-classes.json
@@ -1,0 +1,39 @@
+{
+  "PULSAR_PROVIDER_INVALID_SAVE_MODE": {
+    "message": [
+      "SaveMode <saveMode> is not supported for Pulsar. Please use either SaveMode.Append or SaveMode.ErrorIfExists (default)."
+    ]
+  },
+  "PULSAR_SINK_UNSUPPORTED_DATA_TYPE": {
+    "message": [
+      "The specified data type <dataType> is not supported by Pulsar sink yet."
+    ]
+  },
+  "PULSAR_SINK_INVALID_SCHEMA_TYPE": {
+    "message": [
+      "Schema should have at least one non-key/non-topic field"
+    ]
+  },
+  "PULSAR_SINK_TOPIC_ATTRIBUTE_NAME_MISSING": {
+    "message": [
+      "Topic option is required when no <topicAttributeName> is specified. Use the <topicSingle> option for setting a topic."
+    ]
+  },
+  "PULSAR_SINK_ATTRIBUTE_TYPE_MISMATCH": {
+    "message": [
+      "Type mismatch: Attribute <attributeName> must be the following types: <expectedTypes>."
+    ]
+  },
+  "PULSAR_SINK_PRODUCER_CREATION_FAILURE": {
+    "message": [
+      "Failed to create producer for topic <topic>.",
+      "Details: <details>"
+    ]
+  },
+  "PULSAR_SINK_INCOMPATIBLE_SCHEMA": {
+    "message": [
+      "Cannot write incompatible data to topic <topic>.",
+      "Details: <details>"
+    ]
+  }
+}

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarExceptions.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarExceptions.scala
@@ -1,0 +1,128 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.pulsar
+
+import scala.jdk.CollectionConverters._
+
+import org.apache.spark.{ErrorClassesJsonReader, SparkThrowable}
+
+private object PulsarExceptionsHelper {
+  val errorClassesJsonReader: ErrorClassesJsonReader =
+    new ErrorClassesJsonReader(
+      Seq(getClass.getClassLoader.getResource("error/pulsar-error-classes.json")))
+}
+
+object PulsarExceptions {
+  def pulsarProviderInvalidSaveMode(saveMode: String): PulsarIllegalArgumentException = {
+    new PulsarIllegalArgumentException(
+      errorClass = "PULSAR_PROVIDER_INVALID_SAVE_MODE",
+      messageParameters = Map("saveMode" -> saveMode)
+    )
+  }
+
+  def pulsarSinkUnsupportedDataType(dataType: String): PulsarIllegalArgumentException = {
+    new PulsarIllegalArgumentException(
+      errorClass = "PULSAR_SINK_UNSUPPORTED_DATA_TYPE",
+      messageParameters = Map("dataType" -> dataType)
+    )
+  }
+
+  def pulsarSinkInvalidSchema: PulsarIllegalArgumentException = {
+    new PulsarIllegalArgumentException(
+      errorClass = "PULSAR_SINK_INVALID_SCHEMA",
+      messageParameters = Map()
+    )
+  }
+
+  def pulsarSinkTopicAttributeNameMissing(
+    topicAttributeName: String,
+    topicSingle: String): PulsarIllegalArgumentException = {
+    new PulsarIllegalArgumentException(
+      errorClass = "PULSAR_SINK_TOPIC_ATTRIBUTE_NAME_MISSING",
+      messageParameters = Map("topicAttributeName" -> topicAttributeName,
+        "topicSingle" -> topicSingle)
+    )
+  }
+
+  def pulsarSinkAttributeTypeMismatch(
+    attributeName: String,
+    expectedTypes: List[String]): PulsarIllegalArgumentException = {
+    new PulsarIllegalArgumentException(
+      errorClass = "PULSAR_SINK_ATTRIBUTE_TYPE_MISMATCH",
+      messageParameters = Map("attributeName" -> attributeName,
+        "expectedTypes" -> expectedTypes.mkString(","))
+    )
+  }
+
+  def pulsarSinkIncompatibleSchema(
+    topic: String,
+    cause: Throwable): PulsarIllegalStateException = {
+    new PulsarIllegalStateException(
+      errorClass = "PULSAR_SINK_INCOMPATIBLE_SCHEMA",
+      messageParameters = Map("topic"-> topic, "details" -> cause.getMessage),
+      cause = cause
+    )
+  }
+
+  def pulsarSinkProducerCreationFailure(
+    topic: String,
+    cause: Throwable): PulsarIllegalStateException = {
+    new PulsarIllegalStateException(
+      errorClass = "PULSAR_SINK_PRODUCER_CREATION_FAILURE",
+      messageParameters = Map("topic"-> topic, "details" -> cause.getMessage),
+      cause = cause
+    )
+  }
+}
+
+/**
+ * Illegal state exception thrown with an error class.
+ */
+private[pulsar] class PulsarIllegalStateException(
+  errorClass: String,
+  messageParameters: Map[String, String],
+  cause: Throwable = null)
+  extends IllegalStateException(
+    PulsarExceptionsHelper.errorClassesJsonReader.getErrorMessage(
+      errorClass, messageParameters), cause)
+    with SparkThrowable {
+
+  override def getSqlState: String =
+    PulsarExceptionsHelper.errorClassesJsonReader.getSqlState(errorClass)
+
+  override def getMessageParameters: java.util.Map[String, String] = messageParameters.asJava
+
+  override def getCondition: String = errorClass
+}
+
+
+/**
+ * Illegal argument exception thrown with an error class.
+ */
+private[pulsar] class PulsarIllegalArgumentException(
+  errorClass: String,
+  messageParameters: Map[String, String],
+  cause: Throwable = null)
+  extends IllegalArgumentException(
+    PulsarExceptionsHelper.errorClassesJsonReader.getErrorMessage(
+      errorClass, messageParameters), cause)
+    with SparkThrowable {
+
+  override def getSqlState: String =
+    PulsarExceptionsHelper.errorClassesJsonReader.getSqlState(errorClass)
+
+  override def getMessageParameters: java.util.Map[String, String] = messageParameters.asJava
+
+  override def getCondition: String = errorClass
+}

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarProvider.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarProvider.scala
@@ -21,7 +21,7 @@ import org.apache.pulsar.common.naming.TopicName
 
 import org.apache.spark.SparkEnv
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.{AnalysisException, DataFrame, SaveMode, SparkSession, SQLContext}
+import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession, SQLContext}
 import org.apache.spark.sql.catalyst.json.JSONOptionsInRead
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
@@ -197,10 +197,7 @@ private[pulsar] class PulsarProvider
       data: DataFrame): BaseRelation = {
     mode match {
       case SaveMode.Overwrite | SaveMode.Ignore =>
-        throw new AnalysisException(
-          s"Save mode $mode not allowed for Pulsar. "
-            + s"Allowed save mode are ${SaveMode.Append} and "
-            + s"${SaveMode.ErrorIfExists} (default).")
+        throw PulsarExceptions.pulsarProviderInvalidSaveMode(mode.toString)
       case _ => // good
     }
 

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarRelation.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarRelation.scala
@@ -19,6 +19,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{Row, SQLContext}
 import org.apache.spark.sql.catalyst.json.JSONOptionsInRead
+import org.apache.spark.sql.classic.ClassicConversions.castToImpl
 import org.apache.spark.sql.sources.{BaseRelation, TableScan}
 import org.apache.spark.sql.types.StructType
 
@@ -91,6 +92,6 @@ private[pulsar] class PulsarRelation(
       failOnDataLoss,
       subscriptionNamePrefix,
       jsonOptions)
-    sqlContext.internalCreateDataFrame(rdd.setName("pulsar"), schema).rdd
+      castToImpl(sqlContext).internalCreateDataFrame(rdd.setName("pulsar"), schema).rdd
   }
 }

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarSource.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarSource.scala
@@ -13,28 +13,23 @@
  */
 package org.apache.spark.sql.pulsar
 
-
 import java.{util => ju}
 import java.util.Optional
 
-import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 
-import org.apache.pulsar.client.admin.PulsarAdmin
 import org.apache.pulsar.client.api.MessageId
 import org.apache.pulsar.client.impl.MessageIdImpl
-import org.apache.pulsar.client.internal.DefaultImplementation
 import org.apache.pulsar.common.schema.SchemaInfo
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{DataFrame, SQLContext}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.json.JSONOptionsInRead
+import org.apache.spark.sql.classic.ClassicConversions.castToImpl
 import org.apache.spark.sql.connector.read.streaming
-import org.apache.spark.sql.connector.read.streaming.{ReadAllAvailable, ReadLimit, ReadMaxFiles, ReportsSourceMetrics, SupportsAdmissionControl}
-import org.apache.spark.sql.execution.streaming.{Offset, SerializedOffset, Source}
-import org.apache.spark.sql.pulsar.PulsarOptions.ServiceUrlOptionKey
-import org.apache.spark.sql.pulsar.SpecificPulsarOffset.getTopicOffsets
+import org.apache.spark.sql.connector.read.streaming.{ReadAllAvailable, ReadLimit, ReportsSourceMetrics, SupportsAdmissionControl}
+import org.apache.spark.sql.execution.streaming.{Offset, Source}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.LongAccumulator
 
@@ -122,7 +117,7 @@ private[pulsar] class PulsarSource(
     }
 
     if (start.isDefined && start.get == end) {
-      return sqlContext.internalCreateDataFrame(
+      return castToImpl(sqlContext).internalCreateDataFrame(
         sqlContext.sparkContext.emptyRDD[InternalRow].setName("empty"),
         schema,
         isStreaming = true)
@@ -198,7 +193,8 @@ private[pulsar] class PulsarSource(
       "GetBatch generating RDD of offset range: " +
         offsetRanges.sortBy(_.topic).mkString(", "))
 
-    sqlContext.internalCreateDataFrame(rdd.setName("pulsar"), schema, isStreaming = true)
+    castToImpl(sqlContext)
+      .internalCreateDataFrame(rdd.setName("pulsar"), schema, isStreaming = true)
   }
 
   override def commit(end: Offset): Unit = {

--- a/src/test/scala/org/apache/spark/sql/pulsar/PulsarSinkSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/pulsar/PulsarSinkSuite.scala
@@ -149,13 +149,13 @@ class PulsarSinkSuite extends StreamTest with PulsarTest with SharedSparkSession
 
   test("batch - null topic field value, and no topic option") {
     val df = Seq[(String, String)](null.asInstanceOf[String] -> "1").toDF("topic", "value")
-    val ex = intercept[AnalysisException] {
+    val ex = intercept[PulsarIllegalArgumentException] {
       df.write
         .format("pulsar")
         .option(ServiceUrlOptionKey, serviceUrl)
         .save()
     }
-    assert(ex.getMessage.toLowerCase(Locale.ROOT).contains("topic option required"))
+    assert(ex.getMessage.toLowerCase(Locale.ROOT).contains("topic option is required"))
   }
 
   test("batch - unsupported save modes") {
@@ -163,7 +163,7 @@ class PulsarSinkSuite extends StreamTest with PulsarTest with SharedSparkSession
     val df = Seq[(String, String)](null.asInstanceOf[String] -> "1").toDF("topic", "value")
 
     // Test bad save mode Ignore
-    var ex = intercept[AnalysisException] {
+    var ex = intercept[PulsarIllegalArgumentException] {
       df.write
         .format("pulsar")
         .option(ServiceUrlOptionKey, serviceUrl)
@@ -171,10 +171,10 @@ class PulsarSinkSuite extends StreamTest with PulsarTest with SharedSparkSession
         .save()
     }
     assert(
-      ex.getMessage.toLowerCase(Locale.ROOT).contains(s"save mode ignore not allowed for pulsar"))
+      ex.getMessage.toLowerCase(Locale.ROOT).contains(s"savemode ignore is not supported for pulsar"))
 
     // Test bad save mode Overwrite
-    ex = intercept[AnalysisException] {
+    ex = intercept[PulsarIllegalArgumentException] {
       df.write
         .format("pulsar")
         .option(ServiceUrlOptionKey, serviceUrl)
@@ -184,7 +184,7 @@ class PulsarSinkSuite extends StreamTest with PulsarTest with SharedSparkSession
     assert(
       ex.getMessage
         .toLowerCase(Locale.ROOT)
-        .contains(s"save mode overwrite not allowed for pulsar"))
+        .contains(s"savemode overwrite is not supported for pulsar"))
   }
 
   test("streaming - write to pulsar with topic field") {
@@ -468,7 +468,7 @@ class PulsarSinkSuite extends StreamTest with PulsarTest with SharedSparkSession
     assert(
       ex.getMessage
         .toLowerCase(Locale.ROOT)
-        .contains("key attribute type must be a string or binary"))
+        .contains("type mismatch: attribute __key must be the following types: string,binary"))
 
     try {
       ex = intercept[StreamingQueryException] {
@@ -487,7 +487,7 @@ class PulsarSinkSuite extends StreamTest with PulsarTest with SharedSparkSession
     assert(
       ex.getMessage
         .toLowerCase(Locale.ROOT)
-        .contains("__eventtime attribute type must be a bigint or timestamp"))
+        .contains("type mismatch: attribute __eventtime must be the following types: bigint,timestamp"))
   }
 
   test("batch - write to pulsar with producer conf case sensitive") {

--- a/src/test/scala/org/apache/spark/sql/pulsar/PulsarTest.scala
+++ b/src/test/scala/org/apache/spark/sql/pulsar/PulsarTest.scala
@@ -61,7 +61,7 @@ trait PulsarTest extends BeforeAndAfterAll with BeforeAndAfterEach {
   override def beforeAll(): Unit = {
     pulsarContainer = new PulsarContainer(parse("apachepulsar/pulsar:" + CURRENT_VERSION))
     pulsarContainer.withStartupTimeout(Duration.ofMinutes(5))
-    brokerConfigs.foreach( kv =>
+    brokerConfigs.foreach(kv =>
       pulsarContainer.withEnv("PULSAR_PREFIX_" + kv._1, kv._2)
     )
     pulsarContainer.start()


### PR DESCRIPTION
### Motivation

Spark 4.0.1 has been released in September 2025, the connector needs to support it.

### Modifications

- Upgrade the Spark Version to 4.0.1
- Fix issues caused by Spark API changes in the 4.0.1
    - Introduce `PulsarExceptions` to avoid creating `AnalysisException` with arbitrary error messages
    - Keep using `classic.SqlContext` and `classic.SparkSession` for certain APIs that are not available in Spark 4.0
    - use Java 17
    - Fix breaking tests and compilation 

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.

- [X] This change is already covered by existing tests, such as:

- [ ] This change added tests and can be verified as follows:

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required`
- [x] `no-need-doc`
- [ ] `doc`
