### PR TITLE
Fix: remove incorrect javax.xml shading

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -466,10 +466,6 @@
                   <shadedPattern>org.apache.pulsar.shade.com.google</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>javax.xml</pattern>
-                  <shadedPattern>org.apache.pulsar.shade.javax.xml</shadedPattern>
-                </relocation>
-                <relocation>
                   <pattern>org.apache.avro</pattern>
                   <shadedPattern>org.apache.pulsar.shade.org.apache.avro</shadedPattern>
                 </relocation>


### PR DESCRIPTION
### Motivation

1. `javax.xml.*` classes are part of the JDK, we should NOT be shading them. 
2. This appears to have caused `PulsarAdminException.TimeoutException` when using the pulsar-spark connector with admission control (`getInternalStats()` is called). 

### Modifications
This causes a silent failure which caused the Pulsar Admin server to time out: 
Evidence: we see this warning log:
```
WARN MessagingBinders: A class org.apache.pulsar.shade.javax.xml.transform.sax.SAXSource
    for a default provider MessageBodyReader<org.apache.pulsar.shade.javax.xml.transform.sax.SAXSource>
    was not found. The provider is not available.
```

Sequence of events: 
  Jersey Client Loads StreamSourceProvider class
      ↓
  Checks type parameter: MessageBodyReader<StreamSource>
      ↓
  Looks for: org.apache.pulsar.shade.javax.xml.transform.stream.StreamSource
      ↓
  ClassNotFoundException (doesn't exist - javax.xml is JDK class)
      ↓
  Jersey silently catches exception, can't deserialize
      ↓
  CompletableFuture.get() waits forever and times out

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.

- [x] This change is already covered by existing tests, such as:

- [ ] This change added tests and can be verified as follows:

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required`
- [x] `no-need-doc`
- [ ] `doc`
