### PR TITLE
Upgrade to Spark 4.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <commons-io.version>2.19.0</commons-io.version>
     <testcontainers.version>1.18.3</testcontainers.version>
     <bouncycastle.version>1.78</bouncycastle.version>
-    <jackson.version>2.18.5</jackson.version>
+    <jackson.version>2.20.0</jackson.version>
 
     <!-- plugin dependencies -->
     <maven.version>3.5.4</maven.version>
@@ -113,23 +113,33 @@
     </extraJavaTestArgs>
   </properties>
 
+  <!-- Use Jackson BOM to manage versions (Spark 4.1.1 uses Jackson 2.20.0) -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${jackson.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <!-- dependencies for all modules -->
   <dependencies>
-    <!-- Jackson dependencies - ensure version consistency for tests -->
+    <!-- Jackson dependencies managed by BOM -->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
 
     <!-- pulsar dependency -->

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
   <groupId>io.streamnative.connectors</groupId>
   <artifactId>pulsar-spark-connector_2.13</artifactId>
-  <version>4.0.1-SNAPSHOT</version>
+  <version>4.1.1-SNAPSHOT</version>
   <name>StreamNative :: Pulsar Spark Connector</name>
   <url>https://pulsar.apache.org</url>
   <inceptionYear>2019</inceptionYear>
@@ -67,10 +67,10 @@
     <!-- dependencies -->
     <!-- latest version from apache pulsar -->
     <pulsar.version>4.0.5</pulsar.version>
-    <scala.version>2.13.16</scala.version>
+    <scala.version>2.13.17</scala.version>
     <scala.binary.version>2.13</scala.binary.version>
     <scalatest.version>3.2.14</scalatest.version>
-    <spark.version>4.0.1</spark.version>
+    <spark.version>4.1.1</spark.version>
     <commons-io.version>2.19.0</commons-io.version>
     <testcontainers.version>1.18.3</testcontainers.version>
     <bouncycastle.version>1.78</bouncycastle.version>

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarOffset.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarOffset.scala
@@ -17,7 +17,8 @@ import org.apache.pulsar.client.api.MessageId
 import org.apache.pulsar.client.impl.MessageIdImpl
 
 import org.apache.spark.sql.connector.read.streaming.PartitionOffset
-import org.apache.spark.sql.execution.streaming.{Offset, SerializedOffset}
+import org.apache.spark.sql.execution.streaming.Offset
+import org.apache.spark.sql.execution.streaming.runtime.SerializedOffset
 
 private[pulsar] sealed trait PulsarOffset
 

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarSources.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarSources.scala
@@ -24,7 +24,8 @@ import org.apache.spark.{SparkContext, SparkEnv}
 import org.apache.spark.internal.Logging
 import org.apache.spark.scheduler.ExecutorCacheTaskLocation
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.execution.streaming.{HDFSMetadataLog, SerializedOffset}
+import org.apache.spark.sql.execution.streaming.checkpointing.HDFSMetadataLog
+import org.apache.spark.sql.execution.streaming.runtime.SerializedOffset
 import org.apache.spark.storage.BlockManager
 
 private[pulsar] object PulsarSourceUtils extends Logging {

--- a/src/test/scala/org/apache/spark/sql/pulsar/PulsarMicroBatchSourceSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/pulsar/PulsarMicroBatchSourceSuite.scala
@@ -22,7 +22,7 @@ import org.apache.pulsar.common.naming.NamespaceName
 import org.apache.pulsar.common.policies.data.RetentionPolicies
 import org.apache.spark.SparkException
 import org.apache.spark.sql.ForeachWriter
-import org.apache.spark.sql.execution.streaming.{StreamExecution, StreamingExecutionRelation}
+import org.apache.spark.sql.execution.streaming.runtime.{StreamExecution, StreamingExecutionRelation}
 import org.apache.spark.sql.functions.{col, count, window}
 import org.apache.spark.sql.pulsar.PulsarOptions.{ServiceUrlOptionKey, TopicPattern}
 import org.apache.spark.sql.streaming.StreamingQueryProgress

--- a/src/test/scala/org/apache/spark/sql/pulsar/PulsarSinkSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/pulsar/PulsarSinkSuite.scala
@@ -23,7 +23,7 @@ import org.apache.pulsar.client.api.Schema
 import org.apache.pulsar.common.naming.TopicName
 import org.apache.pulsar.common.schema.SchemaInfo
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, SpecificInternalRow, UnsafeProjection}
-import org.apache.spark.sql.execution.streaming.MemoryStream
+import org.apache.spark.sql.execution.streaming.runtime.MemoryStream
 import org.apache.spark.sql.streaming._
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{BinaryType, DataType}

--- a/src/test/scala/org/apache/spark/sql/pulsar/PulsarSourceOffsetSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/pulsar/PulsarSourceOffsetSuite.scala
@@ -15,15 +15,11 @@ package org.apache.spark.sql.pulsar
 
 import org.apache.pulsar.client.impl.MessageIdImpl
 
-import org.apache.spark.sql.execution.streaming.{
-  LongOffset,
-  OffsetSeq,
-  OffsetSeqLog,
-  SerializedOffset
-}
+import org.apache.spark.sql.execution.streaming.Offset
+import org.apache.spark.sql.execution.streaming.checkpointing.{OffsetSeq, OffsetSeqLog}
+import org.apache.spark.sql.execution.streaming.runtime.{LongOffset, SerializedOffset}
 import org.apache.spark.sql.streaming.OffsetSuite
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.sql.execution.streaming.Offset
 
 import java.io.File
 

--- a/src/test/scala/org/apache/spark/sql/pulsar/PulsarSourceSuiteBase.scala
+++ b/src/test/scala/org/apache/spark/sql/pulsar/PulsarSourceSuiteBase.scala
@@ -20,7 +20,7 @@ import java.util.Locale
 import scala.reflect.ClassTag
 import org.apache.pulsar.client.api.{MessageId, Schema}
 import org.apache.pulsar.common.schema.SchemaInfo
-import org.apache.spark.sql.execution.streaming.StreamExecution
+import org.apache.spark.sql.execution.streaming.runtime.StreamExecution
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.pulsar.PulsarProvider.getPulsarOffset
 import org.apache.spark.sql.streaming.{StreamingQuery, Trigger}

--- a/src/test/scala/org/apache/spark/sql/pulsar/PulsarSourceTest.scala
+++ b/src/test/scala/org/apache/spark/sql/pulsar/PulsarSourceTest.scala
@@ -35,8 +35,10 @@ import org.apache.spark.sql.catalyst.util.stackTraceToString
 import org.apache.spark.sql.classic.ClassicConversions.castToImpl
 import org.apache.spark.sql.connector.read.streaming.SparkDataStream
 import org.apache.spark.sql.execution.datasources.v2.StreamingDataSourceV2ScanRelation
+import org.apache.spark.sql.execution.streaming.Offset
+import org.apache.spark.sql.execution.streaming.operators.stateful.StatefulOperator
 import org.apache.spark.sql.execution.streaming.sources.MemorySink
-import org.apache.spark.sql.execution.streaming._
+import org.apache.spark.sql.execution.streaming.runtime.{MicroBatchExecution, MemoryStream, StreamExecution, StreamingExecutionRelation, StreamingQueryWrapper}
 import org.apache.spark.sql.connector.read.streaming.{Offset => OffsetV2}
 import org.apache.spark.sql.streaming.StreamingQueryListener.{QueryProgressEvent, QueryStartedEvent, QueryTerminatedEvent}
 import org.apache.spark.sql.streaming.{OutputMode, StreamTest, StreamingQueryException, StreamingQueryListener}


### PR DESCRIPTION
## Summary
- Update Spark version from 4.0.1 to 4.1.1
- Update Scala version from 2.13.16 to 2.13.17
- Update project version to 4.1.1-SNAPSHOT
- Update imports for streaming code reorganization in Spark 4.1

## Changes
In Spark 4.1, the streaming code was reorganized ([SPARK-52787](https://issues.apache.org/jira/browse/SPARK-52787)):

| Class | Old Package | New Package |
|-------|-------------|-------------|
| `HDFSMetadataLog` | `execution.streaming` | `execution.streaming.checkpointing` |
| `SerializedOffset` | `execution.streaming` | `execution.streaming.runtime` |
| `LongOffset` | `execution.streaming` | `execution.streaming.runtime` |
| `OffsetSeq`, `OffsetSeqLog` | `execution.streaming` | `execution.streaming.checkpointing` |
| `MemoryStream` | `execution.streaming` | `execution.streaming.runtime` |
| `StreamExecution` | `execution.streaming` | `execution.streaming.runtime` |
| `MicroBatchExecution` | `execution.streaming` | `execution.streaming.runtime` |
| `StreamingQueryWrapper` | `execution.streaming` | `execution.streaming.runtime` |
| `StreamingExecutionRelation` | `execution.streaming` | `execution.streaming.runtime` |
| `StatefulOperator` | `execution.streaming` | `execution.streaming.operators.stateful` |

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

- [ ] This change is a trivial rework / code cleanup without any test coverage.

- [x] This change is already covered by existing tests, such as:

- [ ] This change added tests and can be verified as follows:

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required`
- [x] `no-need-doc`
- [ ] `doc`

🤖 Generated with [Claude Code](https://claude.ai/code)