### PR TITLE
Implement getErrorClass explicitly to avoid AbstractMethodError on Spark builds without the deprecated default

### DIFF
--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarExceptions.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarExceptions.scala
@@ -104,6 +104,13 @@ private[pulsar] class PulsarIllegalStateException(
   override def getMessageParameters: java.util.Map[String, String] = messageParameters.asJava
 
   override def getCondition: String = errorClass
+
+  // Some Spark distributions (notably Databricks Runtime) leave the deprecated
+  // SparkThrowable.getErrorClass abstract instead of defaulting to getCondition.
+  // Implement it explicitly so a thrown exception can be surfaced by Spark's
+  // TaskResultGetter instead of raising AbstractMethodError (which silently hangs
+  // the job). Harmless on OSS Spark, where it overrides the deprecated default.
+  override def getErrorClass: String = errorClass
 }
 
 
@@ -125,4 +132,8 @@ private[pulsar] class PulsarIllegalArgumentException(
   override def getMessageParameters: java.util.Map[String, String] = messageParameters.asJava
 
   override def getCondition: String = errorClass
+
+  // See PulsarIllegalStateException above: explicit override guards against Spark
+  // builds (e.g. Databricks Runtime) that leave SparkThrowable.getErrorClass abstract.
+  override def getErrorClass: String = errorClass
 }

--- a/src/test/scala/org/apache/spark/sql/pulsar/PulsarExceptionsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/pulsar/PulsarExceptionsSuite.scala
@@ -34,9 +34,9 @@ class PulsarExceptionsSuite extends SparkFunSuite {
   }
 
   test("PulsarIllegalArgumentException declares its own getErrorClass") {
-    val e = PulsarExceptions.pulsarSinkInvalidSchema
-    assert(e.getCondition === "PULSAR_SINK_INVALID_SCHEMA")
+    val e = PulsarExceptions.pulsarProviderInvalidSaveMode("Append")
+    assert(e.getCondition === "PULSAR_PROVIDER_INVALID_SAVE_MODE")
     val method = classOf[PulsarIllegalArgumentException].getDeclaredMethod("getErrorClass")
-    assert(method.invoke(e) === "PULSAR_SINK_INVALID_SCHEMA")
+    assert(method.invoke(e) === "PULSAR_PROVIDER_INVALID_SAVE_MODE")
   }
 }

--- a/src/test/scala/org/apache/spark/sql/pulsar/PulsarExceptionsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/pulsar/PulsarExceptionsSuite.scala
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.pulsar
+
+import org.apache.spark.SparkFunSuite
+
+class PulsarExceptionsSuite extends SparkFunSuite {
+
+  // Regression guard for AbstractMethodError on Spark distributions that leave the
+  // deprecated SparkThrowable.getErrorClass abstract (e.g. Databricks Runtime). The
+  // connector exceptions must declare their OWN getErrorClass body; relying on the
+  // interface default causes Spark's TaskResultGetter to raise AbstractMethodError
+  // when the exception escapes a task, which silently hangs the job.
+
+  test("PulsarIllegalStateException declares its own getErrorClass") {
+    val e = PulsarExceptions.pulsarSinkIncompatibleSchema(
+      "persistent://public/default/t", new RuntimeException("boom"))
+    assert(e.getCondition === "PULSAR_SINK_INCOMPATIBLE_SCHEMA")
+    // getDeclaredMethod throws NoSuchMethodException if the body is not on the class
+    // itself (i.e. if it falls back to the SparkThrowable default).
+    val method = classOf[PulsarIllegalStateException].getDeclaredMethod("getErrorClass")
+    assert(method.invoke(e) === "PULSAR_SINK_INCOMPATIBLE_SCHEMA")
+  }
+
+  test("PulsarIllegalArgumentException declares its own getErrorClass") {
+    val e = PulsarExceptions.pulsarSinkInvalidSchema
+    assert(e.getCondition === "PULSAR_SINK_INVALID_SCHEMA")
+    val method = classOf[PulsarIllegalArgumentException].getDeclaredMethod("getErrorClass")
+    assert(method.invoke(e) === "PULSAR_SINK_INVALID_SCHEMA")
+  }
+}


### PR DESCRIPTION
### Motivation

`PulsarIllegalStateException` and `PulsarIllegalArgumentException` implement `SparkThrowable` but override only `getCondition`, relying on the deprecated `SparkThrowable.getErrorClass` default (which delegates to `getCondition`).

On OSS Spark 4.x that is fine — `getErrorClass` is a `@Deprecated default` method method [See here](https://github.com/apache/spark/blob/33b4056eee8ffb5ffe929ca1163fe6ba1d816ac5/common/utils/src/main/java/org/apache/spark/SparkThrowable.java#L49). But some Spark distributions — notably **Databricks Runtime 18 (Spark 4.1)** — ship a `SparkThrowable` where `getErrorClass` is left **abstract** (no default body). When one of these connector exceptions escapes a task, Spark's `TaskResultGetter` virtual-calls `getErrorClass()`, finds no implementation, and throws:

```
java.lang.AbstractMethodError: 'java.lang.String org.apache.spark.SparkThrowable.getErrorClass()'
    at org.apache.spark.sql.pulsar.PulsarIllegalStateException.getErrorClass(PulsarExceptions.scala:92)
```

This kills the result-getter thread, so the *original* failure (e.g. a `PULSAR_SINK_INCOMPATIBLE_SCHEMA` produce error) is never reported and the Spark job **hangs indefinitely** instead of failing. On Databricks that meant multi-hour stuck jobs on idle-but-billed compute, with no error surfaced to the user.

### Modifications

- Implement `getErrorClass` explicitly on both `PulsarIllegalStateException` and `PulsarIllegalArgumentException`, delegating to the error class (same value as `getCondition`). The body then lives on the class itself instead of relying on the interface default. Harmless on OSS Spark (it overrides the deprecated default with the same value); restores correct error propagation on distributions that leave `getErrorClass` abstract.
- Add `PulsarExceptionsSuite`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

- [x] This change added tests and can be verified as follows:

  `PulsarExceptionsSuite` asserts each exception declares its *own* `getErrorClass` (via `getDeclaredMethod`, which throws if the body falls back to the interface default) and returns the expected error class — it fails on the unpatched classes and passes with the fix. Validated locally with `./mvnw -DskipTests test-compile` against Spark 4.1.1.

### Documentation

Check the box below.

Need to update docs?

- [ ] `doc-required`
- [x] `no-need-doc`
- [ ] `doc`

---

_Note: happy to file a linked tracking issue, or take a different approach (e.g. dropping `SparkThrowable` from these two classes entirely) if you'd prefer._
