### PR TITLE
Fix sink schema validation: throw a proper error for value-less schemas

### DIFF
--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarExceptions.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarExceptions.scala
@@ -40,7 +40,7 @@ object PulsarExceptions {
 
   def pulsarSinkInvalidSchema: PulsarIllegalArgumentException = {
     new PulsarIllegalArgumentException(
-      errorClass = "PULSAR_SINK_INVALID_SCHEMA",
+      errorClass = "PULSAR_SINK_INVALID_SCHEMA_TYPE",
       messageParameters = Map()
     )
   }

--- a/src/main/scala/org/apache/spark/sql/pulsar/PulsarSinks.scala
+++ b/src/main/scala/org/apache/spark/sql/pulsar/PulsarSinks.scala
@@ -129,7 +129,7 @@ private[pulsar] object PulsarSinks extends Logging {
       schema.filter(n => !PulsarOptions.MetaFieldNames.contains(n.name))
 
     if (valuesExpression.length == 0) {
-      PulsarExceptions.pulsarSinkInvalidSchema
+      throw PulsarExceptions.pulsarSinkInvalidSchema
     }
 
     checkForUnsupportedType(valuesExpression.map(_.dataType))

--- a/src/test/scala/org/apache/spark/sql/pulsar/PulsarSinkValidateQuerySuite.scala
+++ b/src/test/scala/org/apache/spark/sql/pulsar/PulsarSinkValidateQuerySuite.scala
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.pulsar
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
+import org.apache.spark.sql.types.{BinaryType, StringType}
+
+class PulsarSinkValidateQuerySuite extends SparkFunSuite {
+
+  private val topic = Some("persistent://public/default/t")
+
+  test("validateQuery rejects a schema with no value fields") {
+    // Only a reserved meta field (__key) is present, so there is no value column
+    // to write. validateQuery must throw a PulsarIllegalArgumentException carrying
+    // PULSAR_SINK_INVALID_SCHEMA_TYPE. Previously this raised INTERNAL_ERROR (the
+    // error class did not match error/pulsar-error-classes.json) and the exception
+    // was never actually thrown (missing `throw`), so the check was a no-op.
+    val schema = Seq(AttributeReference(PulsarOptions.KeyAttributeName, BinaryType)())
+    val e = intercept[PulsarIllegalArgumentException] {
+      PulsarSinks.validateQuery(schema, topic)
+    }
+    assert(e.getCondition === "PULSAR_SINK_INVALID_SCHEMA_TYPE")
+  }
+
+  test("validateQuery accepts a schema with at least one value field") {
+    val schema = Seq(
+      AttributeReference(PulsarOptions.KeyAttributeName, BinaryType)(),
+      AttributeReference("value", StringType)())
+    // Should not throw.
+    PulsarSinks.validateQuery(schema, topic)
+  }
+}


### PR DESCRIPTION
### Motivation

`PulsarSinks.validateQuery` is meant to reject a sink schema that has no value columns (only reserved meta fields such as `__key`/`__topic`). Two bugs make that guard ineffective:

1. **Missing `throw`.** `PulsarExceptions.pulsarSinkInvalidSchema` appears as a bare statement with no `throw`, so the exception is constructed and discarded — validation falls through and the write proceeds with no value column.
2. **Undefined error class.** The factory references error class `PULSAR_SINK_INVALID_SCHEMA`, which is not present in `error/pulsar-error-classes.json` (the defined key is `PULSAR_SINK_INVALID_SCHEMA_TYPE`). So merely *evaluating* the factory raises `INTERNAL_ERROR: Cannot find main error class 'PULSAR_SINK_INVALID_SCHEMA'` instead of the intended message ("Schema should have at least one non-key/non-topic field"). This bug currently masks #1.

### Modifications

- `PulsarSinks.validateQuery`: add the missing `throw`.
- `PulsarExceptions.pulsarSinkInvalidSchema`: use the defined error class `PULSAR_SINK_INVALID_SCHEMA_TYPE`.
- Add `PulsarSinkValidateQuerySuite` covering both the reject and accept paths.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

- [x] This change added tests and can be verified as follows:

  `PulsarSinkValidateQuerySuite`: a meta-only schema (`__key` + topic option) now throws `PulsarIllegalArgumentException` with condition `PULSAR_SINK_INVALID_SCHEMA_TYPE`; a schema with a value field passes. The reject test fails on the current code (no exception is thrown / `INTERNAL_ERROR`) and passes with the fix. Verified locally with `./mvnw test -Dsuites='org.apache.spark.sql.pulsar.PulsarSinkValidateQuerySuite'`.

### Documentation

Check the box below.

Need to update docs?

- [ ] `doc-required`
- [x] `no-need-doc`
- [ ] `doc`
